### PR TITLE
Issue #7: Enable presenting group to score raised hands (0-3 points)

### DIFF
--- a/.github/SPRINT_2.md
+++ b/.github/SPRINT_2.md
@@ -48,14 +48,14 @@ Scenario 1：成功解析並匯入階層式名單
 
 接受條件
 
-Scenario 1: 設定組長
+Scenario 1: 設定評分者
 - Given 報告組成員已登入，而且老師已經設定報告組別
-- When 報告組別同學可以看到「我是組長」的按鈕
-- Then 第一位按下「我是組長」的同學成為組長，負責給分。
+- When 報告組別同學可以看到「我負責評分」的按鈕
+- Then 第一位按下「我負責評分」的同學負責給分。
 
 Scenario 2:  給發問組分數
-- Given 報告組已經設定組長
-- When 組長可以看到同學舉手，報告組別依順序給發問組分數( 0–3 )並送出
+- Given 報告組已經設定評分者
+- When 評分者可以看到同學舉手，評分者依順序給發問組分數( 0–3 )並送出
 - Then 系統新增 `participation_logs`（含 `classId, group, points, timestamp, handRef?, givenBy`）並回傳 200；Scoreboard 在可見時段反映分數變動。
 
 Scenario 3: 非組長送分
@@ -64,8 +64,8 @@ Scenario 3: 非組長送分
 - Then 回傳 403 + { error: "非報告組組長" }。
 
 Scenario 4: 分數超範圍 
-- Given 分數超範圍
-- When 發出請求
+- Given 分數超範圍 ( 0–3 )
+- When 發出請求 (如:5分)
 - Then 回傳 400 + { error: "分數超範圍" }。
 
 ---

--- a/.github/SPRINT_2.md
+++ b/.github/SPRINT_2.md
@@ -46,7 +46,44 @@ Scenario 1：成功解析並匯入階層式名單
 
 身為 報告組同學，我想要 在台上直接點選發問同學並給予 **0-3 分**，因此我可以 實質回饋對我們報告有幫助的建議。
 
+接受條件
 
+Scenario 1: 設定組長
+- Given 報告組成員已登入，而且老師已經設定報告組別
+- When 報告組別同學可以看到「我是組長」的按鈕
+- Then 第一位按下「我是組長」的同學成為組長，負責給分。
+
+Scenario 2:  給發問組分數
+- Given 報告組已經設定組長
+- When 組長可以看到同學舉手，報告組別依順序給發問組分數( 0–3 )並送出
+- Then 系統新增 `participation_logs`（含 `classId, group, points, timestamp, handRef?, givenBy`）並回傳 200；Scoreboard 在可見時段反映分數變動。
+
+Scenario 3: 非組長送分
+- Given 非報告組成員送分或者非組長送分
+- When 發出請求
+- Then 回傳 403 + { error: "非報告組組長" }。
+
+Scenario 4: 分數超範圍 
+- Given 分數超範圍
+- When 發出請求
+- Then 回傳 400 + { error: "分數超範圍" }。
+
+---
+**注意事項**
+#28 要能知道是否有同學設定自己為組長，萬一設定錯誤，也可以重新指定組長
+
+---
+
+**最終決議 (2026-04-02)**
+
+- 分數制：教師採 1–5（整數）；報告組相關互評採 0–3（整數）；不允許小數或負值。
+- 情境（明確三種）：
+  1. 教師加分（全域權限）：教師可隨時對任意小組給分，採 1–5。
+  2. 教師提問情境：教師提問並由學生/小組回答時，回答小組的評分採 0–3；教師可在此情境額外給分（1–5）。
+  3. 學生報告情境：小組上台報告時，評分方（報告組或其他指定小組）採 0–3；教師可額外給分（1–5）。
+- 計分目標：系統僅對小組（group）計分；個人分數由小組分配規則另行定義。
+- 審計與資料保留：`participation_logs` 為長期保留之審計紀錄（課程結束後清除）；即時 Scoreboard 應使用 denormalized 聚合欄位或 background job 更新，避免每次從日誌重算。
+- API 與實作建議：在給分 endpoint 中依 `givenBy.role` 驗證範圍（教師 1..5，報告組/學生 0..3），所有寫入與 hands resolving 建議以 transaction 或原子作業完成，並同時寫入 `participation_logs` 與更新 denormalized 聚合欄位。
 
 
 ### Issue #24: 學生：登入系統
@@ -86,41 +123,40 @@ Scenario 3：登入失敗
 - URL: https://github.com/jitsungwu/sa2026/issues/10
 
 身為 在班學生，我想要 登入後查詢自己目前的累計點數，因此我可以 瞭解自己的平時表現並適時調整參與度。
+接受條件
+Scenario 1: 
+- Given 報告組成員已登入，而且老師已經設定報告組別
+- When 報告組別可以看到同學舉手，報告組別依順序給發問組分數( 0–3 )並送出
+- Then 系統新增 `participation_logs`（含 `classId, group, points, timestamp, handRef?, givenBy`）並回傳 200；Scoreboard 在可見時段反映分數變動。
 
-Scenario 1:
-- Given 學生登入查看分數
-- When 提出要求
-- Then 
-  - 展示分數
-  - 使用 denormalized `group_score` 欄位以提升效能（或說明為 eventual consistency）
-  - UI 同時展示最後更新時間與一致性說明。
+Scenario 2:
+- Given 非報告組成員送分
+- When 發出請求
+- Then 回傳 403 + { error: "非報告組" }。
+
+Scenario 3: 
+- Given 分數超範圍
+- When 發出請求
+- Then 回傳 400 + { error: "分數超範圍" }。
+
+Scenario 4:
+- Given 相同的組別只有第一位登入的同學可以給分，其他同學不能給分
+- When 重複送出
+- Then 回傳 409 + { error: "重複計分" }。並不重複計分。
 
 
-### Issue #14: 學生: 登入時選擇座位 (位置設定)
-- State: OPEN
-- Labels: -
-- URL: https://github.com/jitsungwu/sa2026/issues/14
+---
 
-身為 同學，我想要 在登入時於「虛擬座位表」選擇我的座位，因此我可以 提供組別的實體位置供系統紀錄。
-Scenario 1: 首次選擇組別位置 (Happy Path)
-- Given (前提)： 
-  - 我已登入，系統自動檢查班級及組別。
-  - 系統顯示 白板在前，並且由右到左有三大區，左邊有6排、中間有8排、右邊有8排的教室網格。
-- When (當操作發生時)： 
-  - 我點擊座標 (行2, 列3) 的空白方格並確認。
-- Then (預期結果)： 
-  - 系統應在 Firestore 的 classes/class-A/layout 中更新該座標為 groupId: 3。
-  - 該方格顏色應立即變更為我所屬組別的高亮色，並導向互動儀表板。
+**最終決議 (2026-04-02)**
 
-Scenario 2: 防止座位衝突 (Conflict Prevention)
-- Given (前提)：
-  - 「第 1 組」已經選擇了座標 (行1, 列1)。
-  - When (當操作發生時)：
-  - 我（第 3 組）嘗試點擊已被佔用的 (行1, 列1) 時。
-  - Then (預期結果)： 
-  - 系統應顯示提示「此位置已被第 1 組選取」，且不允許我提交。介面應透過 onSnapshot 即時更新，將已被選取的格子設為 disabled。
-
-Scenario 3: 組員重複選擇處理 (Group Consensus)
+- 分數制：教師採 1–5（整數）；報告組相關互評採 0–3（整數）；不允許小數或負值。
+- 情境（明確三種）：
+  1. 教師加分（全域權限）：教師可隨時對任意小組給分，採 1–5。
+  2. 教師提問情境：教師提問並由學生/小組回答時，回答小組的評分採 0–3；教師可在此情境額外給分（1–5）。
+  3. 學生報告情境：小組上台報告時，評分方（報告組或其他指定小組）採 0–3；教師可額外給分（1–5）。
+- 計分目標：系統僅對小組（group）計分；個人分數由小組分配規則另行定義。
+- 審計與資料保留：`participation_logs` 為長期保留之審計紀錄（課程結束後清除）；即時 Scoreboard 應使用 denormalized 聚合欄位或 background job 更新，避免每次從日誌重算。
+- API 與實作建議：在給分 endpoint 中依 `givenBy.role` 驗證範圍（教師 1..5，報告組/學生 0..3），所有寫入與 hands resolving 建議以 transaction 或原子作業完成，並同時寫入 `participation_logs` 與更新 denormalized 聚合欄位。
 - Given (前提)：
   - 我的同組隊友已經在另一台手機選好了位置。
   - When (當操作發生時)：

--- a/.github/skills/qa-workflow.md
+++ b/.github/skills/qa-workflow.md
@@ -1,3 +1,15 @@
+---
+name: qa-workflow
+description: "Use when running E2E tests or unit tests. Automatically manage Vitest and Playwright test execution with environment validation, pre-checks, per-check confirmation points, and cleanup."
+applyTo:
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/*.test.js"
+  - "**/*.test.jsx"
+  - "**/*.spec.js"
+  - "**/*.spec.ts"
+---
+
 # Skill: Smart QA & Testing Pipeline (Vitest & Playwright)
 
 ## [Description]

--- a/e2e/11-presenting-scorer.spec.js
+++ b/e2e/11-presenting-scorer.spec.js
@@ -107,6 +107,11 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   const scorerUrl = `${base}/class/student?group=${GROUP_ID}&participantId=${scorerStudentId}`
   console.log('Scorer URL:', scorerUrl)
   await scorerPage.goto(scorerUrl, { waitUntil: 'domcontentloaded' })
+  
+  // Set studentAuth in localStorage for the scorer
+  await scorerPage.evaluate((studentId) => {
+    localStorage.setItem('studentAuth', JSON.stringify({ account: studentId }))
+  }, scorerStudentId)
 
   // Wait for the "我負責評分" button to appear (with longer timeout for Firestore data load)
   const claimBtn = scorerPage.locator('button:has-text("我負責評分")')
@@ -139,6 +144,15 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   // This student should be able to raise hand since they're not in the presenting group
   const otherStudentPage = await browser.newPage()
   
+  const otherUrl = `${base}/class/student?group=01&participantId=${otherStudentId}`
+  console.log('Other student URL:', otherUrl)
+  await otherStudentPage.goto(otherUrl, { waitUntil: 'domcontentloaded' })
+  
+  // Set studentAuth in localStorage for the other student
+  await otherStudentPage.evaluate((studentId) => {
+    localStorage.setItem('studentAuth', JSON.stringify({ account: studentId }))
+  }, otherStudentId)
+  
   // Capture console messages
   const consoleLogs = []
   otherStudentPage.on('console', msg => {
@@ -148,10 +162,6 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
     })
     console.log(`[${msg.type()}] ${msg.text()}`)
   })
-  
-  const otherUrl = `${base}/class/student?group=01&participantId=${otherStudentId}`
-  console.log('Other student URL:', otherUrl)
-  await otherStudentPage.goto(otherUrl, { waitUntil: 'domcontentloaded' })
 
   // Wait for page to fully load and Firestore listeners to initialize
   await otherStudentPage.waitForTimeout(3000)

--- a/e2e/11-presenting-scorer.spec.js
+++ b/e2e/11-presenting-scorer.spec.js
@@ -1,0 +1,198 @@
+import { test, expect } from './test-fixtures'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.local' })
+
+test('presenting group: assign scorer and allow raising', async ({ page, browser }, testInfo) => {
+  testInfo.setTimeout(90000) // Increase timeout to 90 seconds
+  const base = process.env.BASE_URL || 'http://localhost:3000'
+  const email = process.env.TEACHER_ID
+  const password = process.env.TEACHER_PASSWORD
+  const TEST_CLASS = process.env.TEST_CLASS_ID || 'demo'
+  const GROUP_ID = process.env.TEST_PRESENTING_GROUP || '04'
+  
+  // Student accounts for testing
+  const scorerStudentId = '413000005' // 04 group - will claim scorer role
+  const otherStudentId = '413000001' // 01 group - will raise hand
+
+  // Teacher page: sign in if necessary and ensure class active
+  await page.goto(`${base}/class/monitor`, { waitUntil: 'domcontentloaded' })
+  const loggedInBtn = await page.$('button:has-text("登出")')
+  if (!loggedInBtn) {
+    test.skip(!email || !password, 'TEACHER_ID or TEACHER_PASSWORD not provided in .env.local')
+    await page.goto(`${base}/signin`)
+    // Click "教師登入" button to show teacher form
+    await page.click('button:has-text("教師登入")')
+    await page.waitForSelector('input[placeholder="email@example.com"]', { timeout: 5000 })
+    await page.fill('input[placeholder="email@example.com"]', email)
+    await page.fill('input[type="password"]', password)
+    await page.click('button:has-text("登入")')
+    await page.waitForSelector('button:has-text("登出")', { timeout: 10000 })
+    await page.goto(`${base}/class/monitor`)
+  }
+
+  // Activate class if needed
+  const activateBtn = await page.$('button:has-text("啟動班級")')
+  if (activateBtn) {
+    const sel = await page.$('select')
+    if (sel) {
+      const opt = await page.$(`select option[value="${TEST_CLASS}"]`)
+      if (opt) await page.selectOption('select', TEST_CLASS)
+      else await page.selectOption('select', { index: 0 })
+    }
+    await page.click('button:has-text("啟動班級")')
+    // wait for activation
+    for (let i = 0; i < 15; i++) {
+      const header = await page.textContent('h1').catch(() => '')
+      if (header && !header.includes('尚未啟動')) break
+      await page.waitForTimeout(1000)
+    }
+  }
+  
+  // Wait for activation - check if monitor shows hands or class in active state
+  let classActived = false
+  for (let i = 0; i < 20; i++) {
+    // Check if there's a "即時舉手名單" or other indicator of active class
+    const monitorContent = await page.textContent('main').catch(() => '')
+    if (monitorContent && monitorContent.includes('即時舉手')) {
+      classActived = true
+      break
+    }
+    await page.waitForTimeout(500)
+  }
+  
+  if (!classActived) {
+    console.warn('Could not confirm class activation, proceeding anyway')
+  }
+  
+  console.log('Proceeding with test (class activation status uncertain due to encoding issues)')
+
+  // Set presenting group via monitor UI
+  await page.waitForSelector('#presenting-group-input', { timeout: 10000 })
+  
+  // First, clear any previous presenting group state by clicking "結束報告" if it exists
+  const endBtn = await page.$('button:has-text("結束報告")')
+  if (endBtn) {
+    await page.click('button:has-text("結束報告")')
+    // Wait for Firestore to process the update
+    await page.waitForTimeout(2000)
+  }
+
+  // Verify both fields are now null in the monitor UI
+  await page.waitForFunction(() => {
+    const elements = document.querySelectorAll('div')
+    for (let el of elements) {
+      if (el.textContent && el.textContent.includes('目前報告中')) {
+        return false
+      }
+    }
+    return true
+  }, { timeout: 5000 }).catch(() => {})
+
+  await page.fill('#presenting-group-input', GROUP_ID)
+  await page.click('button:has-text("設為報告組")')
+
+  // Wait for the monitor UI to reflect presenting group
+  await page.waitForFunction((g) => {
+    const el = Array.from(document.querySelectorAll('strong')).find(s => s.textContent === g)
+    return !!el
+  }, GROUP_ID, { timeout: 8000 })
+
+  // Give Firestore time to sync the presentingGroupId
+  await page.waitForTimeout(2000)
+
+  // Open a student page in a separate browser context to simulate claiming scorer
+  // Student 413000005 from group 04 will claim the scorer role
+  const scorerPage = await browser.newPage()
+  const scorerUrl = `${base}/class/student?group=${GROUP_ID}&participantId=${scorerStudentId}`
+  console.log('Scorer URL:', scorerUrl)
+  await scorerPage.goto(scorerUrl, { waitUntil: 'domcontentloaded' })
+
+  // Wait for the "我負責評分" button to appear (with longer timeout for Firestore data load)
+  const claimBtn = scorerPage.locator('button:has-text("我負責評分")')
+  try {
+    await claimBtn.waitFor({ timeout: 15000 }) // Wait for button to be visible with generous timeout
+  } catch (e) {
+    // If button doesn't appear, take screenshot and check page content for debugging
+    await scorerPage.screenshot({ path: 'test-results/scorer-button-missing.png' })
+    const body = await scorerPage.textContent('body')
+    console.error('Scorer page body content:', body)
+    throw e
+  }
+  await expect(claimBtn).toHaveCount(1)
+
+  // Click to claim scorer role
+  await claimBtn.click()
+
+  // After claiming, the claim button should disappear (or be disabled) and raise button should be available
+  await expect(claimBtn).toHaveCount(0)
+
+  // Verify raise hand button is now available for the scorer
+  const scorerRaiseBtn = scorerPage.locator('button:has-text("舉手")')
+  await expect(scorerRaiseBtn).toHaveCount(1)
+
+  // Now open another student page - student from different group (413000001 from group 01)
+  // This student should be able to raise hand since they're not in the presenting group
+  const otherStudentPage = await browser.newPage()
+  
+  // Capture console messages
+  const consoleLogs = []
+  otherStudentPage.on('console', msg => {
+    consoleLogs.push({
+      type: msg.type(),
+      text: msg.text()
+    })
+    console.log(`[${msg.type()}] ${msg.text()}`)
+  })
+  
+  const otherUrl = `${base}/class/student?group=01&participantId=${otherStudentId}`
+  console.log('Other student URL:', otherUrl)
+  await otherStudentPage.goto(otherUrl, { waitUntil: 'domcontentloaded' })
+
+  // Wait for page to fully load and Firestore listeners to initialize
+  await otherStudentPage.waitForTimeout(3000)
+
+  // For the other student (not in presenting group), the raise hand button should be available
+  const otherRaiseBtn = otherStudentPage.locator('button:has-text("舉手")')
+  await expect(otherRaiseBtn).toHaveCount(1)
+
+  // Click raise hand button with simple click
+  console.log('Clicking raise hand for student 413000001')
+  
+  await otherRaiseBtn.first().click()
+  
+  console.log('Raise hand button clicked, waiting for Firestore sync and UI update...')
+  
+  // Wait longer for Firestore write and listener update
+  // The onSnapshot listener should update once the hands_raised document is added
+  for (let i = 0; i < 30; i++) {
+    const cancelCount = await otherStudentPage.locator('button:has-text("取消舉手")').count()
+    const raiseCount = await otherStudentPage.locator('button:has-text("舉手")').count()
+    const raiseText = await otherStudentPage.locator('span:has-text("已舉手")').count()
+    console.log(`Attempt ${i+1}/30: cancel=${cancelCount}, raise=${raiseCount}, raised-text=${raiseText}`)
+    
+    if (cancelCount > 0 || raiseText > 0) {
+      console.log('UI updated successfully!')
+      break
+    }
+    await otherStudentPage.waitForTimeout(1000)
+  }
+  
+  // Check if cancel button appears
+  const otherCancelBtn = otherStudentPage.locator('button:has-text("取消舉手")')
+  const cancelCount = await otherCancelBtn.count()
+  
+  console.log('Final check - Cancel button found:', cancelCount)
+  
+  if (cancelCount === 0) {
+    // Debug: check page content
+    const bodyText = await otherStudentPage.textContent('body')
+    console.error('Page content after raise:', bodyText.substring(0, 500))
+    await otherStudentPage.screenshot({ path: 'test-results/after-raise.png' })
+  }
+  
+  await expect(otherCancelBtn).toHaveCount(1)
+
+  await scorerPage.close()
+  await otherStudentPage.close()
+})

--- a/e2e/11-presenting-scorer.spec.js
+++ b/e2e/11-presenting-scorer.spec.js
@@ -124,12 +124,16 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   // Click to claim scorer role
   await claimBtn.click()
 
-  // After claiming, the claim button should disappear (or be disabled) and raise button should be available
+  // After claiming, the claim button should disappear
   await expect(claimBtn).toHaveCount(0)
 
-  // Verify raise hand button is now available for the scorer
+  // Verify that scorer cannot raise hand (displaying info text instead of button)
+  // Scorers in presenting group cannot raise hands after claiming scorer role
   const scorerRaiseBtn = scorerPage.locator('button:has-text("舉手")')
-  await expect(scorerRaiseBtn).toHaveCount(1)
+  await expect(scorerRaiseBtn).toHaveCount(0)  // Should be 0 now since they're assigned as scorer
+
+  // Wait for scoring interface to appear
+  await scorerPage.waitForTimeout(2000)
 
   // Now open another student page - student from different group (413000001 from group 01)
   // This student should be able to raise hand since they're not in the presenting group

--- a/e2e/simple-raise-hand.spec.js
+++ b/e2e/simple-raise-hand.spec.js
@@ -1,0 +1,56 @@
+import { test, expect } from './test-fixtures'
+import dotenv from 'dotenv'
+
+dotenv.config({ path: '.env.local' })
+
+test('simple raise hand', async ({ page }) => {
+  const base = process.env.BASE_URL || 'http://localhost:3000'
+  const TEST_CLASS = process.env.TEST_CLASS_ID || 'demo'
+  const studentId = '413000001'
+
+  // Go directly to student page without teacher setup
+  // This assumes a class is already active
+  const studentUrl = `${base}/class/student?group=01&participantId=${studentId}`
+  console.log('Student URL:', studentUrl)
+  
+  await page.goto(studentUrl, { waitUntil: 'domcontentloaded' })
+  console.log('Page loaded')
+  
+  // Wait for page to fully initialize
+  await page.waitForTimeout(5000)
+  console.log('After initial wait')
+
+  // Look for raise hand button
+  const raiseBtn = page.locator('button:has-text("舉手")')
+  const count = await raiseBtn.count()
+  console.log('Raise button count:', count)
+  
+  if (count === 0) {
+    const body = await page.textContent('body')
+    console.error('Body content:', body.substring(0, 300))
+  }
+  
+  await expect(raiseBtn).toHaveCount(1)
+  console.log('Raise button found')
+
+  // Click raise hand
+  console.log('Clicking raise hand button')
+  await raiseBtn.first().click()
+  
+  // Wait for state update
+  await page.waitForTimeout(5000)
+  console.log('After click wait')
+
+  // Check for cancel button
+  const cancelBtn = page.locator('button:has-text("取消舉手")')
+  const cancelCount = await cancelBtn.count()
+  console.log('Cancel button count:', cancelCount)
+  
+  if (cancelCount === 0) {
+    const body = await page.textContent('body')
+    console.error('Body after raise:', body.substring(0, 300))
+  }
+  
+  await expect(cancelBtn).toHaveCount(1)
+  console.log('Test passed!')
+})

--- a/e2e/test-accounts.json
+++ b/e2e/test-accounts.json
@@ -1,12 +1,6 @@
 {
   "disponible": [
     {
-      "account": "413000009",
-      "classId": "demo",
-      "groupId": "03",
-      "status": "available"
-    },
-    {
       "account": "413000010",
       "classId": "demo",
       "groupId": "04",
@@ -69,6 +63,13 @@
       "groupId": "03",
       "status": "available",
       "usedAt": "2026-04-06T05:17:58.981Z"
+    },
+    {
+      "account": "413000009",
+      "classId": "demo",
+      "groupId": "03",
+      "status": "available",
+      "usedAt": "2026-04-07T03:10:42.502Z"
     }
   ]
 }

--- a/src/app/api/score-hand/route.js
+++ b/src/app/api/score-hand/route.js
@@ -1,0 +1,102 @@
+import { db } from '@/firebaseClient'
+import { doc, updateDoc, collection, addDoc, serverTimestamp, getDoc } from '@/lib/firestoreWrapper'
+
+export async function POST(request) {
+  try {
+    const { classId, handId, points, givenBy } = await request.json()
+
+    // Validation
+    if (!classId || !handId || points === undefined || !givenBy) {
+      return Response.json(
+        { error: 'Missing required fields' },
+        { status: 400 }
+      )
+    }
+
+    if (points < 0 || points > 3 || !Number.isInteger(points)) {
+      return Response.json(
+        { error: '分數必須為 0-3 之間的整數' },
+        { status: 400 }
+      )
+    }
+
+    // Get the hand document to verify group
+    const handRef = doc(db, 'hands_raised', handId)
+    const handSnap = await getDoc(handRef)
+
+    if (!handSnap.exists()) {
+      return Response.json(
+        { error: '舉手記錄不存在' },
+        { status: 404 }
+      )
+    }
+
+    const handData = handSnap.data()
+
+    // Get class to verify scorer
+    const classRef = doc(db, 'classes', classId)
+    const classSnap = await getDoc(classRef)
+
+    if (!classSnap.exists()) {
+      return Response.json(
+        { error: '班級不存在' },
+        { status: 404 }
+      )
+    }
+
+    const classData = classSnap.data()
+
+    // Check if givenBy is the current scorer
+    if (classData.presentingScorerOwnerId !== givenBy) {
+      return Response.json(
+        { error: '非報告組組長' },
+        { status: 403 }
+      )
+    }
+
+    // Check if group matches presenting group
+    const presentingGroupNum = parseInt(String(classData.presentingGroupId), 10)
+    const handGroupNum = parseInt(String(handData.group), 10)
+    if (presentingGroupNum !== handGroupNum) {
+      return Response.json(
+        { error: '只能評分自己組別的舉手' },
+        { status: 403 }
+      )
+    }
+
+    // Mark hand as resolved
+    await updateDoc(handRef, {
+      active: false,
+      resolved: true,
+      resolvedScore: points,
+      resolvedBy: givenBy,
+      resolvedAt: serverTimestamp()
+    })
+
+    // Add to participation_logs
+    const logRef = await addDoc(collection(db, 'participation_logs'), {
+      classId,
+      group: handData.group,
+      points,
+      timestamp: serverTimestamp(),
+      handRef: handId,
+      givenBy,
+      givenByRole: 'presenting_scorer'
+    })
+
+    return Response.json(
+      { 
+        success: true, 
+        logId: logRef.id,
+        message: '給分成功'
+      },
+      { status: 200 }
+    )
+  } catch (err) {
+    console.error('Score hand error:', err)
+    return Response.json(
+      { error: err.message || '給分失敗' },
+      { status: 500 }
+    )
+  }
+}

--- a/src/app/api/score-hand/route.js
+++ b/src/app/api/score-hand/route.js
@@ -1,5 +1,5 @@
-import { db } from '@/firebaseClient'
-import { doc, updateDoc, collection, addDoc, serverTimestamp, getDoc } from '@/lib/firestoreWrapper'
+import { db } from '../../../firebaseClient'
+import { doc, updateDoc, collection, addDoc, serverTimestamp, getDoc } from '../../../lib/firestoreWrapper'
 
 export async function POST(request) {
   try {
@@ -50,16 +50,6 @@ export async function POST(request) {
     if (classData.presentingScorerOwnerId !== givenBy) {
       return Response.json(
         { error: '非報告組組長' },
-        { status: 403 }
-      )
-    }
-
-    // Check if group matches presenting group
-    const presentingGroupNum = parseInt(String(classData.presentingGroupId), 10)
-    const handGroupNum = parseInt(String(handData.group), 10)
-    if (presentingGroupNum !== handGroupNum) {
-      return Response.json(
-        { error: '只能評分自己組別的舉手' },
         { status: 403 }
       )
     }

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -13,7 +13,6 @@ export default function StudentDashboardPage() {
   const [student, setStudent] = useState(null)
   const [seatInfo, setSeatInfo] = useState(null)
   const [loading, setLoading] = useState(false)
-  const [activeTab, setActiveTab] = useState('seat') // 'seat', 'raise', 'reporting'
   const [presentingGroupId, setPresentingGroupId] = useState(null)
   const [presentingScorerOwnerId, setPresentingScorerOwnerId] = useState(null)
 
@@ -130,121 +129,46 @@ export default function StudentDashboardPage() {
           <h1>學生互動儀表板</h1>
       
       {/* 學生基本資訊 */}
-      <div style={{ marginBottom: 20, padding: 12, backgroundColor: '#f0f0f0', borderRadius: 6 }}>
-        <p><strong>學號：</strong> {student.account}</p>
-        <p><strong>姓名：</strong> {student.name || '未提供'}</p>
-        <p><strong>組別：</strong> {student.groupId}</p>
-        <p><strong>班級：</strong> {student.classId}</p>
+      <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#f0f0f0', borderRadius: 6, border: '1px solid #ddd' }}>
+        <h2 style={{ marginTop: 0 }}>學生信息</h2>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
+          <p><strong>學號：</strong> {student.account}</p>
+          <p><strong>姓名：</strong> {student.name || '未提供'}</p>
+          <p><strong>組別：</strong> {student.groupId}</p>
+          <p><strong>班級：</strong> {student.classId}</p>
+        </div>
         <p><strong>座位位置：</strong> {seatInfo ? `${seatInfo.zone}第 ${seatInfo.row} 排` : '未選座位'}</p>
-      </div>
-
-      {/* Tab 導航 */}
-      <div style={{ marginBottom: 20, borderBottom: '2px solid #ddd', display: 'flex', gap: 0 }}>
-        <button
-          onClick={() => setActiveTab('seat')}
-          style={{
-            padding: '12px 24px',
-            backgroundColor: activeTab === 'seat' ? '#1890ff' : '#f0f0f0',
-            color: activeTab === 'seat' ? '#fff' : '#000',
-            border: 'none',
-            cursor: 'pointer',
-            fontSize: '14px',
-            fontWeight: activeTab === 'seat' ? 'bold' : 'normal',
-            transition: 'all 0.2s'
-          }}
-        >
-          📍 座位信息
-        </button>
-        <button
-          onClick={() => setActiveTab('raise')}
-          style={{
-            padding: '12px 24px',
-            backgroundColor: activeTab === 'raise' ? '#1890ff' : '#f0f0f0',
-            color: activeTab === 'raise' ? '#fff' : '#000',
-            border: 'none',
-            cursor: 'pointer',
-            fontSize: '14px',
-            fontWeight: activeTab === 'raise' ? 'bold' : 'normal',
-            transition: 'all 0.2s'
-          }}
-        >
-          ✋ 舉手/積分
-        </button>
-        {isUserInPresentingGroup() && (
-          <button
-            onClick={() => setActiveTab('reporting')}
-            style={{
-              padding: '12px 24px',
-              backgroundColor: activeTab === 'reporting' ? '#52c41a' : '#f0f0f0',
-              color: activeTab === 'reporting' ? '#fff' : '#000',
-              border: 'none',
-              cursor: 'pointer',
-              fontSize: '14px',
-              fontWeight: activeTab === 'reporting' ? 'bold' : 'normal',
-              transition: 'all 0.2s'
-            }}
-          >
-            📊 報告組評分
-          </button>
+        {!seatInfo && (
+          <p style={{ color: '#cf1322', fontSize: '0.9em' }}>
+            ⚠️ <a href={`/class/${classId}/seat-selection`} style={{ color: '#0050b3' }}>點擊重新選擇座位</a>
+          </p>
         )}
       </div>
 
-      {/* Tab 內容 */}
-      <div style={{ marginBottom: 20 }}>
-        {/* 座位信息 Tab */}
-        {activeTab === 'seat' && (
-          <div>
-            <h2>座位信息</h2>
-            {seatInfo ? (
-              <div style={{ padding: 12, backgroundColor: '#e6f7ff', borderRadius: 4 }}>
-                <p><strong>位置：</strong> {seatInfo.zone}第 {seatInfo.row} 排</p>
-                <p style={{ fontSize: '0.9em', color: '#666' }}>提示：需要更改座位請先<a href={`/class/${classId}/seat-selection`}>重新選擇</a></p>
-              </div>
-            ) : (
-              <div style={{ padding: 12, backgroundColor: '#fff7e6', borderRadius: 4, color: '#856404' }}>
-                <p>⚠️ 未選座位，請立即<a href={`/class/${classId}/seat-selection`} style={{ color: '#0050b3' }}>選擇座位</a></p>
-              </div>
-            )}
-          </div>
-        )}
-
-        {/* 舉手/積分 Tab */}
-        {activeTab === 'raise' && (
-          <div>
-            <h2>舉手/積分榜</h2>
-            <div style={{ marginBottom: 16 }}>
-              <h3>舉手操制</h3>
-              <RaiseHandButton classId={classId} group={student.groupId} />
-            </div>
-            <div>
-              <h3>即時積分榜</h3>
-              <Scoreboard classId={classId} />
-            </div>
-          </div>
-        )}
-
-        {/* 報告組評分 Tab */}
-        {activeTab === 'reporting' && isUserInPresentingGroup() && (
-          <div>
-            <h2>報告組評分介面</h2>
-            <div style={{ marginBottom: 16, padding: 12, backgroundColor: '#fff3cd', borderRadius: 4 }}>
-              <p style={{ margin: 0, color: '#856404' }}>
-                ℹ️ 你所在的 {student.groupId} 組正在報告中
-              </p>
-            </div>
-            <RaiseHandButton classId={classId} group={student.groupId} />
-            <PresentingGroupScorer 
-              classId={classId} 
-              group={student.groupId} 
-              presentingScorerOwnerId={presentingScorerOwnerId} 
-            />
-            <div style={{ marginTop: 20 }}>
-              <h3>班級積分榜</h3>
-              <Scoreboard classId={classId} />
-            </div>
-          </div>
-        )}
+      {/* 舉手操制 */}
+      <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#f9f9f9', borderRadius: 6, border: '1px solid #eee' }}>
+        <h2 style={{ marginTop: 0 }}>舉手操制</h2>
+        <RaiseHandButton classId={classId} group={student.groupId} />
       </div>
+
+      {/* 即時積分榜 */}
+      <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#f9f9f9', borderRadius: 6, border: '1px solid #eee' }}>
+        <h2 style={{ marginTop: 0 }}>即時積分榜</h2>
+        <Scoreboard classId={classId} />
+      </div>
+
+      {/* 報告組評分（條件顯示） */}
+      {isUserInPresentingGroup() && (
+        <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#fffbe6', borderRadius: 6, border: '1px solid #ffe58f' }}>
+          <h2 style={{ marginTop: 0, color: '#856404' }}>📊 報告組評分介面</h2>
+          <p style={{ color: '#666', marginBottom: 16 }}>你所在的 {student.groupId} 組正在報告中</p>
+          <PresentingGroupScorer 
+            classId={classId} 
+            group={student.groupId} 
+            presentingScorerOwnerId={presentingScorerOwnerId} 
+          />
+        </div>
+      )}
 
       {/* 登出按鈕 */}
       <div>

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -2,7 +2,10 @@
 import React, { useEffect, useState } from 'react'
 import { useParams } from 'next/navigation'
 import { db } from '../../../../firebaseClient'
-import { doc, getDoc } from 'firebase/firestore'
+import { doc, getDoc, onSnapshot } from '../../../../lib/firestoreWrapper'
+import RaiseHandButton from '../../../../components/RaiseHandButton'
+import Scoreboard from '../../../../components/Scoreboard'
+import PresentingGroupScorer from '../../../../components/PresentingGroupScorer'
 
 export default function StudentDashboardPage() {
   const params = useParams()
@@ -10,6 +13,9 @@ export default function StudentDashboardPage() {
   const [student, setStudent] = useState(null)
   const [seatInfo, setSeatInfo] = useState(null)
   const [loading, setLoading] = useState(false)
+  const [activeTab, setActiveTab] = useState('seat') // 'seat', 'raise', 'reporting'
+  const [presentingGroupId, setPresentingGroupId] = useState(null)
+  const [presentingScorerOwnerId, setPresentingScorerOwnerId] = useState(null)
 
   useEffect(() => {
     const authStr = typeof window !== 'undefined' ? localStorage.getItem('studentAuth') : null
@@ -77,20 +83,53 @@ export default function StudentDashboardPage() {
     fetchSeatInfo()
   }, [student, classId])
 
-  if (!student) {
-    return (
-      <div style={{ padding: 24 }}>
-        <p>未登入或登入已過期，請重新登入。</p>
-        <a href="/signin" style={{ color: '#0070f3', textDecoration: 'underline' }}>
-          回到登入頁面
-        </a>
-      </div>
-    )
+  // Listen for presenting group info
+  useEffect(() => {
+    if (!classId || !db) return
+
+    try {
+      const classRef = doc(db, 'classes', classId)
+      const unsub = onSnapshot(classRef, (snap) => {
+        if (snap && typeof snap.data === 'function') {
+          const data = snap.data() || {}
+          setPresentingGroupId(data.presentingGroupId || null)
+          setPresentingScorerOwnerId(data.presentingScorerOwnerId || null)
+        } else {
+          setPresentingGroupId(null)
+          setPresentingScorerOwnerId(null)
+        }
+      }, (err) => console.error('Listen presenting group error:', err))
+
+      return () => unsub()
+    } catch (e) {
+      console.error('subscribe class doc error:', e)
+    }
+  }, [classId])
+
+  // Check if user is in presenting group
+  const isUserInPresentingGroup = () => {
+    if (!presentingGroupId || !student) return false
+    const presentingNum = parseInt(String(presentingGroupId), 10)
+    const studentNum = parseInt(String(student.groupId), 10)
+    return presentingNum === studentNum && !isNaN(presentingNum) && !isNaN(studentNum)
   }
 
   return (
-    <div style={{ padding: 24 }}>
-      <h1>學生互動儀表板</h1>
+    <div style={{ padding: 24, maxWidth: 1000, margin: '0 auto' }}>
+      
+      {!student ? (
+        <>
+          <h1>未登入</h1>
+          <p>未登入或登入已過期，請重新登入。</p>
+          <a href="/signin" style={{ color: '#0070f3', textDecoration: 'underline' }}>
+            回到登入頁面
+          </a>
+        </>
+      ) : (
+        <>
+          <h1>學生互動儀表板</h1>
+      
+      {/* 學生基本資訊 */}
       <div style={{ marginBottom: 20, padding: 12, backgroundColor: '#f0f0f0', borderRadius: 6 }}>
         <p><strong>學號：</strong> {student.account}</p>
         <p><strong>姓名：</strong> {student.name || '未提供'}</p>
@@ -99,32 +138,136 @@ export default function StudentDashboardPage() {
         <p><strong>座位位置：</strong> {seatInfo ? `${seatInfo.zone}第 ${seatInfo.row} 排` : '未選座位'}</p>
       </div>
 
-      <div style={{ marginBottom: 20 }}>
-        <h2>功能列表（開發中）</h2>
-        <ul>
-          <li>舉手機制</li>
-          <li>查看累計分數</li>
-          <li>選擇座位</li>
-          <li>虛擬座位表</li>
-        </ul>
+      {/* Tab 導航 */}
+      <div style={{ marginBottom: 20, borderBottom: '2px solid #ddd', display: 'flex', gap: 0 }}>
+        <button
+          onClick={() => setActiveTab('seat')}
+          style={{
+            padding: '12px 24px',
+            backgroundColor: activeTab === 'seat' ? '#1890ff' : '#f0f0f0',
+            color: activeTab === 'seat' ? '#fff' : '#000',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: '14px',
+            fontWeight: activeTab === 'seat' ? 'bold' : 'normal',
+            transition: 'all 0.2s'
+          }}
+        >
+          📍 座位信息
+        </button>
+        <button
+          onClick={() => setActiveTab('raise')}
+          style={{
+            padding: '12px 24px',
+            backgroundColor: activeTab === 'raise' ? '#1890ff' : '#f0f0f0',
+            color: activeTab === 'raise' ? '#fff' : '#000',
+            border: 'none',
+            cursor: 'pointer',
+            fontSize: '14px',
+            fontWeight: activeTab === 'raise' ? 'bold' : 'normal',
+            transition: 'all 0.2s'
+          }}
+        >
+          ✋ 舉手/積分
+        </button>
+        {isUserInPresentingGroup() && (
+          <button
+            onClick={() => setActiveTab('reporting')}
+            style={{
+              padding: '12px 24px',
+              backgroundColor: activeTab === 'reporting' ? '#52c41a' : '#f0f0f0',
+              color: activeTab === 'reporting' ? '#fff' : '#000',
+              border: 'none',
+              cursor: 'pointer',
+              fontSize: '14px',
+              fontWeight: activeTab === 'reporting' ? 'bold' : 'normal',
+              transition: 'all 0.2s'
+            }}
+          >
+            📊 報告組評分
+          </button>
+        )}
       </div>
 
+      {/* Tab 內容 */}
+      <div style={{ marginBottom: 20 }}>
+        {/* 座位信息 Tab */}
+        {activeTab === 'seat' && (
+          <div>
+            <h2>座位信息</h2>
+            {seatInfo ? (
+              <div style={{ padding: 12, backgroundColor: '#e6f7ff', borderRadius: 4 }}>
+                <p><strong>位置：</strong> {seatInfo.zone}第 {seatInfo.row} 排</p>
+                <p style={{ fontSize: '0.9em', color: '#666' }}>提示：需要更改座位請先<a href={`/class/${classId}/seat-selection`}>重新選擇</a></p>
+              </div>
+            ) : (
+              <div style={{ padding: 12, backgroundColor: '#fff7e6', borderRadius: 4, color: '#856404' }}>
+                <p>⚠️ 未選座位，請立即<a href={`/class/${classId}/seat-selection`} style={{ color: '#0050b3' }}>選擇座位</a></p>
+              </div>
+            )}
+          </div>
+        )}
+
+        {/* 舉手/積分 Tab */}
+        {activeTab === 'raise' && (
+          <div>
+            <h2>舉手/積分榜</h2>
+            <div style={{ marginBottom: 16 }}>
+              <h3>舉手操制</h3>
+              <RaiseHandButton classId={classId} group={student.groupId} />
+            </div>
+            <div>
+              <h3>即時積分榜</h3>
+              <Scoreboard classId={classId} />
+            </div>
+          </div>
+        )}
+
+        {/* 報告組評分 Tab */}
+        {activeTab === 'reporting' && isUserInPresentingGroup() && (
+          <div>
+            <h2>報告組評分介面</h2>
+            <div style={{ marginBottom: 16, padding: 12, backgroundColor: '#fff3cd', borderRadius: 4 }}>
+              <p style={{ margin: 0, color: '#856404' }}>
+                ℹ️ 你所在的 {student.groupId} 組正在報告中
+              </p>
+            </div>
+            <RaiseHandButton classId={classId} group={student.groupId} />
+            <PresentingGroupScorer 
+              classId={classId} 
+              group={student.groupId} 
+              presentingScorerOwnerId={presentingScorerOwnerId} 
+            />
+            <div style={{ marginTop: 20 }}>
+              <h3>班級積分榜</h3>
+              <Scoreboard classId={classId} />
+            </div>
+          </div>
+        )}
+      </div>
+
+      {/* 登出按鈕 */}
       <div>
-        <a
-          href="/signin"
+        <button
+          onClick={() => {
+            localStorage.removeItem('studentAuth')
+            window.location.href = '/signin'
+          }}
           style={{
-            display: 'inline-block',
             padding: '8px 16px',
             backgroundColor: '#f03',
             color: 'white',
-            textDecoration: 'none',
-            borderRadius: 4
+            border: 'none',
+            borderRadius: 4,
+            cursor: 'pointer',
+            fontWeight: 'bold'
           }}
-          onClick={() => localStorage.removeItem('studentAuth')}
         >
           登出
-        </a>
+        </button>
       </div>
+        </>
+      )}
     </div>
   )
 }

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -118,8 +118,8 @@ export default function StudentDashboardPage() {
       
       {!student ? (
         <>
-          <h1>未登入</h1>
-          <p>未登入或登入已過期，請重新登入。</p>
+          <h1 style={{ fontSize: '2em' }}>未登入</h1>
+          <p style={{ fontSize: '1em' }}>未登入或登入已過期，請重新登入。</p>
           <a href="/signin" style={{ color: '#0070f3', textDecoration: 'underline' }}>
             回到登入頁面
           </a>
@@ -129,9 +129,9 @@ export default function StudentDashboardPage() {
           <h1>學生互動儀表板</h1>
       
       {/* 個人資訊 */}
-      <div style={{ marginBottom: 16, padding: 12, backgroundColor: '#f0f0f0', borderRadius: 6, border: '1px solid #ddd', fontSize: '0.9em' }}>
-        <h3 style={{ marginTop: 0, marginBottom: 8 }}>個人資訊</h3>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontSize: '0.85em' }}>
+      <div style={{ marginBottom: 16, padding: 12, backgroundColor: '#f0f0f0', borderRadius: 6, border: '1px solid #ddd' }}>
+        <h3 style={{ marginTop: 0, marginBottom: 8, fontSize: '1em', fontWeight: 'bold' }}>個人資訊</h3>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontSize: '1em' }}>
           <p style={{ margin: 4 }}><strong>{student.account}</strong></p>
           <p style={{ margin: 4 }}>{student.name || '未提供'} | {student.groupId}組</p>
           <p style={{ margin: 4 }}>座位：{seatInfo ? `${seatInfo.zone}第 ${seatInfo.row} 排` : '未選'}</p>
@@ -150,7 +150,7 @@ export default function StudentDashboardPage() {
         
         {isUserInPresentingGroup() && (
           <div style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid #ddd' }}>
-            <p style={{ color: '#666', marginBottom: 16, fontSize: '0.9em' }}>📊 你所在的 {student.groupId} 組正在報告中</p>
+            <p style={{ color: '#666', marginBottom: 16, fontSize: '1em' }}>📊 你所在的 {student.groupId} 組正在報告中</p>
             <PresentingGroupScorer 
               classId={classId} 
               group={student.groupId} 

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -130,15 +130,14 @@ export default function StudentDashboardPage() {
       
       {/* 個人資訊 */}
       <div style={{ marginBottom: 16, padding: 12, backgroundColor: '#f0f0f0', borderRadius: 6, border: '1px solid #ddd' }}>
-        <h3 style={{ marginTop: 0, marginBottom: 8, fontSize: '1em', fontWeight: 'bold' }}>個人資訊</h3>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontSize: '1em' }}>
-          <p style={{ margin: 4 }}><strong>{student.account}</strong></p>
-          <p style={{ margin: 4 }}>{student.name || '未提供'} | {student.groupId}組</p>
-          <p style={{ margin: 4 }}>座位：{seatInfo ? `${seatInfo.zone}第 ${seatInfo.row} 排` : '未選'}</p>
+        <div style={{ display: 'flex', gap: 16, fontSize: '1em', alignItems: 'center', flexWrap: 'wrap' }}>
+          <span><strong>{student.account}</strong></span>
+          <span>{student.name || '未提供'} | {student.groupId}組</span>
+          <span>座位：{seatInfo ? `${seatInfo.zone}第 ${seatInfo.row} 排` : '未選'}</span>
           {!seatInfo && (
-            <p style={{ margin: 4, color: '#cf1322' }}>
+            <span style={{ color: '#cf1322' }}>
               <a href={`/class/${classId}/seat-selection`} style={{ color: '#0050b3' }}>重新選座位</a>
-            </p>
+            </span>
           )}
         </div>
       </div>

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -142,9 +142,9 @@ export default function StudentDashboardPage() {
         </div>
       </div>
 
-      {/* 報告組功能 */}
+      {/* 互動功能 */}
       <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#f9f9f9', borderRadius: 6, border: '1px solid #eee' }}>
-        <h2 style={{ marginTop: 0 }}>報告組功能</h2>
+        <h2 style={{ marginTop: 0 }}>互動功能</h2>
         <RaiseHandButton classId={classId} group={student.groupId} />
         
         {isUserInPresentingGroup() && (

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -145,10 +145,22 @@ export default function StudentDashboardPage() {
         )}
       </div>
 
-      {/* 舉手操制 */}
+      {/* 舉手操制 & 報告組評分 */}
       <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#f9f9f9', borderRadius: 6, border: '1px solid #eee' }}>
         <h2 style={{ marginTop: 0 }}>舉手操制</h2>
         <RaiseHandButton classId={classId} group={student.groupId} />
+        
+        {isUserInPresentingGroup() && (
+          <div style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid #ddd' }}>
+            <h3 style={{ marginTop: 0, color: '#856404' }}>📊 報告組評分介面</h3>
+            <p style={{ color: '#666', marginBottom: 16, fontSize: '0.9em' }}>你所在的 {student.groupId} 組正在報告中</p>
+            <PresentingGroupScorer 
+              classId={classId} 
+              group={student.groupId} 
+              presentingScorerOwnerId={presentingScorerOwnerId} 
+            />
+          </div>
+        )}
       </div>
 
       {/* 即時積分榜 */}
@@ -156,19 +168,6 @@ export default function StudentDashboardPage() {
         <h2 style={{ marginTop: 0 }}>即時積分榜</h2>
         <Scoreboard classId={classId} />
       </div>
-
-      {/* 報告組評分（條件顯示） */}
-      {isUserInPresentingGroup() && (
-        <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#fffbe6', borderRadius: 6, border: '1px solid #ffe58f' }}>
-          <h2 style={{ marginTop: 0, color: '#856404' }}>📊 報告組評分介面</h2>
-          <p style={{ color: '#666', marginBottom: 16 }}>你所在的 {student.groupId} 組正在報告中</p>
-          <PresentingGroupScorer 
-            classId={classId} 
-            group={student.groupId} 
-            presentingScorerOwnerId={presentingScorerOwnerId} 
-          />
-        </div>
-      )}
 
       {/* 登出按鈕 */}
       <div>

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -103,7 +103,7 @@ export default function StudentDashboardPage() {
     } catch (e) {
       console.error('subscribe class doc error:', e)
     }
-  }, [classId])
+  }, [classId, db])
 
   // Check if user is in presenting group
   const isUserInPresentingGroup = () => {

--- a/src/app/class/[classId]/dashboard/page.jsx
+++ b/src/app/class/[classId]/dashboard/page.jsx
@@ -128,32 +128,29 @@ export default function StudentDashboardPage() {
         <>
           <h1>學生互動儀表板</h1>
       
-      {/* 學生基本資訊 */}
-      <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#f0f0f0', borderRadius: 6, border: '1px solid #ddd' }}>
-        <h2 style={{ marginTop: 0 }}>學生信息</h2>
-        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 12 }}>
-          <p><strong>學號：</strong> {student.account}</p>
-          <p><strong>姓名：</strong> {student.name || '未提供'}</p>
-          <p><strong>組別：</strong> {student.groupId}</p>
-          <p><strong>班級：</strong> {student.classId}</p>
+      {/* 個人資訊 */}
+      <div style={{ marginBottom: 16, padding: 12, backgroundColor: '#f0f0f0', borderRadius: 6, border: '1px solid #ddd', fontSize: '0.9em' }}>
+        <h3 style={{ marginTop: 0, marginBottom: 8 }}>個人資訊</h3>
+        <div style={{ display: 'grid', gridTemplateColumns: '1fr 1fr', gap: 8, fontSize: '0.85em' }}>
+          <p style={{ margin: 4 }}><strong>{student.account}</strong></p>
+          <p style={{ margin: 4 }}>{student.name || '未提供'} | {student.groupId}組</p>
+          <p style={{ margin: 4 }}>座位：{seatInfo ? `${seatInfo.zone}第 ${seatInfo.row} 排` : '未選'}</p>
+          {!seatInfo && (
+            <p style={{ margin: 4, color: '#cf1322' }}>
+              <a href={`/class/${classId}/seat-selection`} style={{ color: '#0050b3' }}>重新選座位</a>
+            </p>
+          )}
         </div>
-        <p><strong>座位位置：</strong> {seatInfo ? `${seatInfo.zone}第 ${seatInfo.row} 排` : '未選座位'}</p>
-        {!seatInfo && (
-          <p style={{ color: '#cf1322', fontSize: '0.9em' }}>
-            ⚠️ <a href={`/class/${classId}/seat-selection`} style={{ color: '#0050b3' }}>點擊重新選擇座位</a>
-          </p>
-        )}
       </div>
 
-      {/* 舉手操制 & 報告組評分 */}
+      {/* 報告組功能 */}
       <div style={{ marginBottom: 24, padding: 16, backgroundColor: '#f9f9f9', borderRadius: 6, border: '1px solid #eee' }}>
-        <h2 style={{ marginTop: 0 }}>舉手操制</h2>
+        <h2 style={{ marginTop: 0 }}>報告組功能</h2>
         <RaiseHandButton classId={classId} group={student.groupId} />
         
         {isUserInPresentingGroup() && (
           <div style={{ marginTop: 24, paddingTop: 16, borderTop: '1px solid #ddd' }}>
-            <h3 style={{ marginTop: 0, color: '#856404' }}>📊 報告組評分介面</h3>
-            <p style={{ color: '#666', marginBottom: 16, fontSize: '0.9em' }}>你所在的 {student.groupId} 組正在報告中</p>
+            <p style={{ color: '#666', marginBottom: 16, fontSize: '0.9em' }}>📊 你所在的 {student.groupId} 組正在報告中</p>
             <PresentingGroupScorer 
               classId={classId} 
               group={student.groupId} 

--- a/src/components/HandsMonitor.jsx
+++ b/src/components/HandsMonitor.jsx
@@ -133,8 +133,10 @@ export default function HandsMonitor({ classId, isOwner }) {
                 <strong>{presentingGroup || '無'}</strong>
                 {presentingGroup && (
                   <>
-                    {!presentingScorerOwnerId && (
+                    {!presentingScorerOwnerId ? (
                       <span style={{ marginLeft: 12, color: '#d46b08', fontWeight: 'bold' }}>⏳ 尚未指定評分者</span>
+                    ) : (
+                      <span style={{ marginLeft: 12, color: '#52c41a', fontWeight: 'bold' }}>✓ 評分者：{presentingScorerOwnerId}</span>
                     )}
                     <button style={{ marginLeft: 12 }} onClick={endPresenting}>結束報告</button>
                   </>

--- a/src/components/HandsMonitor.jsx
+++ b/src/components/HandsMonitor.jsx
@@ -27,7 +27,7 @@ export default function HandsMonitor({ classId, isOwner }) {
   }, [classId])
 
   useEffect(() => {
-    if (!classId) return
+    if (!classId || !db) return
     const classRef = doc(db, 'classes', classId)
     const unsubClass = onSnapshot(classRef, (snap) => {
       if (snap && typeof snap.data === 'function') {
@@ -41,7 +41,7 @@ export default function HandsMonitor({ classId, isOwner }) {
     }, (err) => console.error('class doc snapshot error:', err))
 
     return () => unsubClass()
-  }, [classId])
+  }, [classId, db])
 
   const handleAward = async (hand) => {
     // default wrapper: award 1 point

--- a/src/components/HandsMonitor.jsx
+++ b/src/components/HandsMonitor.jsx
@@ -107,7 +107,7 @@ export default function HandsMonitor({ classId, isOwner }) {
   const endPresenting = async () => {
     if (!isOwner) { alert('僅老師可結束報告'); return }
     try {
-      await updateDoc(doc(db, 'classes', classId), { presentingGroupId: null })
+      await updateDoc(doc(db, 'classes', classId), { presentingGroupId: null, presentingScorerOwnerId: null })
     } catch (err) {
       console.error('結束報告錯誤：', err)
     }

--- a/src/components/HandsMonitor.jsx
+++ b/src/components/HandsMonitor.jsx
@@ -6,6 +6,7 @@ import { collection, query, where, orderBy, onSnapshot, addDoc, serverTimestamp,
 export default function HandsMonitor({ classId, isOwner }) {
   const [hands, setHands] = useState([])
   const [presentingGroup, setPresentingGroup] = useState(null)
+  const [presentingScorerOwnerId, setPresentingScorerOwnerId] = useState(null)
 
   useEffect(() => {
     if (!classId) return
@@ -32,8 +33,10 @@ export default function HandsMonitor({ classId, isOwner }) {
       if (snap && typeof snap.data === 'function') {
         const data = snap.data() || {}
         setPresentingGroup(data.presentingGroupId || null)
+        setPresentingScorerOwnerId(data.presentingScorerOwnerId || null)
       } else {
         setPresentingGroup(null)
+        setPresentingScorerOwnerId(null)
       }
     }, (err) => console.error('class doc snapshot error:', err))
 
@@ -128,7 +131,14 @@ export default function HandsMonitor({ classId, isOwner }) {
               <div style={{ marginBottom: 8 }}>
                 <span style={{ marginRight: 8 }}>目前報告組：</span>
                 <strong>{presentingGroup || '無'}</strong>
-                {presentingGroup && <button style={{ marginLeft: 12 }} onClick={endPresenting}>結束報告</button>}
+                {presentingGroup && (
+                  <>
+                    {!presentingScorerOwnerId && (
+                      <span style={{ marginLeft: 12, color: '#d46b08', fontWeight: 'bold' }}>⏳ 尚未指定評分者</span>
+                    )}
+                    <button style={{ marginLeft: 12 }} onClick={endPresenting}>結束報告</button>
+                  </>
+                )}
               </div>
               <label style={{ marginRight: 8 }}>設為報告組（請保留前置零，例如 04）：</label>
               <input id="presenting-group-input" type="text" style={{ width: 80, marginRight: 12 }} />

--- a/src/components/PresentingGroupScorer.jsx
+++ b/src/components/PresentingGroupScorer.jsx
@@ -1,13 +1,30 @@
 "use client"
 import React, { useEffect, useState } from "react"
 import { db } from "../firebaseClient"
-import { collection, query, where, onSnapshot, doc, updateDoc, serverTimestamp, addDoc } from "../lib/firestoreWrapper"
+import { collection, query, where, onSnapshot } from "../lib/firestoreWrapper"
 
 export default function PresentingGroupScorer({ classId, group, presentingScorerOwnerId }) {
   const [hands, setHands] = useState([]) // Array of raised hands
   const [loading, setLoading] = useState(false)
   const [scoringHand, setScoringHand] = useState(null) // Currently scoring hand
   const [selectedScore, setSelectedScore] = useState(0)
+  const [participantId, setParticipantId] = useState(null)
+  const [error, setError] = useState(null)
+
+  // Get current participant ID (same logic as RaiseHandButton)
+  useEffect(() => {
+    let id = null
+    try {
+      const params = new URLSearchParams(window.location.search)
+      id = params.get('participantId') || null
+    } catch (e) {
+      id = null
+    }
+    if (!id) {
+      id = `p_${Date.now()}_${Math.floor(Math.random()*10000)}`
+    }
+    setParticipantId(id)
+  }, [])
 
   // Listen for raised hands in current group
   useEffect(() => {
@@ -45,40 +62,42 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
 
   const handleScore = async (handId) => {
     if (!handId || selectedScore < 0 || selectedScore > 3) {
-      alert('請選擇 0-3 分')
+      setError('請選擇 0-3 分')
+      return
+    }
+
+    // Check authorization
+    if (participantId !== presentingScorerOwnerId) {
+      setError('非報告組組長，無法給分')
       return
     }
 
     setLoading(true)
+    setError(null)
     try {
-      // Mark hand as resolved with the score
-      await updateDoc(doc(db, 'hands_raised', handId), {
-        active: false,
-        resolved: true,
-        resolvedScore: selectedScore,
-        resolvedBy: presentingScorerOwnerId,
-        resolvedAt: serverTimestamp()
+      // Call API to score
+      const response = await fetch('/api/score-hand', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          classId,
+          handId,
+          points: selectedScore,
+          givenBy: participantId
+        })
       })
 
-      // Add to participation_logs
-      const hand = hands.find(h => h.id === handId)
-      if (hand) {
-        await addDoc(collection(db, 'participation_logs'), {
-          classId,
-          group: hand.group,
-          points: selectedScore,
-          timestamp: serverTimestamp(),
-          handRef: handId,
-          givenBy: presentingScorerOwnerId,
-          givenByRole: 'presenting_scorer'
-        })
+      const data = await response.json()
+
+      if (!response.ok) {
+        throw new Error(data.error || '給分失敗')
       }
 
       setScoringHand(null)
       setSelectedScore(0)
     } catch (err) {
       console.error('Score error:', err)
-      alert('給分失敗：' + err.message)
+      setError(err.message)
     } finally {
       setLoading(false)
     }
@@ -91,6 +110,20 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
   return (
     <div style={{ marginTop: 16, padding: 12, backgroundColor: '#e7f3ff', borderRadius: 4, border: '1px solid #91d5ff' }}>
       <h3 style={{ marginTop: 0, color: '#0050b3' }}>✍️ 給分介面</h3>
+
+      {/* Authorization check */}
+      {participantId && presentingScorerOwnerId && participantId !== presentingScorerOwnerId && (
+        <div style={{ padding: 8, backgroundColor: '#fff1f0', border: '1px solid #ffa39e', borderRadius: 4, marginBottom: 12, color: '#c41d7f' }}>
+          ⚠️ 你不是評分者，無法給分
+        </div>
+      )}
+
+      {/* Error message */}
+      {error && (
+        <div style={{ padding: 8, backgroundColor: '#fff1f0', border: '1px solid #ffa39e', borderRadius: 4, marginBottom: 12, color: '#cf1322' }}>
+          ❌ {error}
+        </div>
+      )}
 
       {hands.length === 0 ? (
         <div style={{ color: '#999', fontStyle: 'italic' }}>目前沒有學生舉手</div>
@@ -109,10 +142,15 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
                   backgroundColor: scoringHand?.id === hand.id ? '#fff7e6' : '#f0f2f5',
                   borderRadius: 4,
                   border: scoringHand?.id === hand.id ? '2px solid #faad14' : '1px solid #d9d9d9',
-                  cursor: 'pointer',
+                  cursor: participantId === presentingScorerOwnerId ? 'pointer' : 'not-allowed',
+                  opacity: participantId === presentingScorerOwnerId ? 1 : 0.6,
                   transition: 'all 0.2s'
                 }}
-                onClick={() => setScoringHand(hand)}
+                onClick={() => {
+                  if (participantId === presentingScorerOwnerId) {
+                    setScoringHand(hand)
+                  }
+                }}
               >
                 <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
                   <span style={{ fontWeight: 'bold' }}>
@@ -152,18 +190,18 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
                         disabled={loading || selectedScore < 0 || selectedScore > 3}
                         style={{
                           padding: '6px 16px',
-                          backgroundColor: '#52c41a',
+                          backgroundColor: loading ? '#999' : '#52c41a',
                           color: '#fff',
                           border: 'none',
                           borderRadius: 4,
-                          cursor: 'pointer',
+                          cursor: loading ? 'not-allowed' : 'pointer',
                           fontWeight: 'bold'
                         }}
                       >
                         {loading ? '提交中...' : '確認給分'}
                       </button>
                       <button
-                        onClick={() => setScoringHand(null)}
+                        onClick={() => { setScoringHand(null); setError(null) }}
                         style={{
                           padding: '6px 16px',
                           backgroundColor: '#f5f5f5',

--- a/src/components/PresentingGroupScorer.jsx
+++ b/src/components/PresentingGroupScorer.jsx
@@ -56,7 +56,7 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
     } catch (e) {
       console.error('subscribe hands error:', e)
     }
-  }, [classId, group])
+  }, [classId, group, db])
 
   const handleScore = async (handId) => {
     if (!handId || selectedScore < 0 || selectedScore > 3) {

--- a/src/components/PresentingGroupScorer.jsx
+++ b/src/components/PresentingGroupScorer.jsx
@@ -1,0 +1,188 @@
+"use client"
+import React, { useEffect, useState } from "react"
+import { db } from "../firebaseClient"
+import { collection, query, where, onSnapshot, doc, updateDoc, serverTimestamp, addDoc } from "../lib/firestoreWrapper"
+
+export default function PresentingGroupScorer({ classId, group, presentingScorerOwnerId }) {
+  const [hands, setHands] = useState([]) // Array of raised hands
+  const [loading, setLoading] = useState(false)
+  const [scoringHand, setScoringHand] = useState(null) // Currently scoring hand
+  const [selectedScore, setSelectedScore] = useState(0)
+
+  // Listen for raised hands in current group
+  useEffect(() => {
+    if (!classId || !group) return
+
+    try {
+      // Convert group to match Firestore format
+      const groupStr = String(group)
+      const col = collection(db, 'hands_raised')
+      const q = query(
+        col,
+        where('classId', '==', classId),
+        where('group', '==', groupStr),
+        where('active', '==', true)
+      )
+
+      const unsub = onSnapshot(q, (snapshot) => {
+        const hands = snapshot.docs.map(doc => ({
+          id: doc.id,
+          ...doc.data(),
+          timestamp: doc.data().timestamp?.toDate?.() || new Date()
+        }))
+        // Sort by timestamp (earliest first)
+        hands.sort((a, b) => a.timestamp - b.timestamp)
+        setHands(hands)
+      }, (err) => {
+        console.error('Listen hands error:', err)
+      })
+
+      return () => unsub()
+    } catch (e) {
+      console.error('subscribe hands error:', e)
+    }
+  }, [classId, group])
+
+  const handleScore = async (handId) => {
+    if (!handId || selectedScore < 0 || selectedScore > 3) {
+      alert('請選擇 0-3 分')
+      return
+    }
+
+    setLoading(true)
+    try {
+      // Mark hand as resolved with the score
+      await updateDoc(doc(db, 'hands_raised', handId), {
+        active: false,
+        resolved: true,
+        resolvedScore: selectedScore,
+        resolvedBy: presentingScorerOwnerId,
+        resolvedAt: serverTimestamp()
+      })
+
+      // Add to participation_logs
+      const hand = hands.find(h => h.id === handId)
+      if (hand) {
+        await addDoc(collection(db, 'participation_logs'), {
+          classId,
+          group: hand.group,
+          points: selectedScore,
+          timestamp: serverTimestamp(),
+          handRef: handId,
+          givenBy: presentingScorerOwnerId,
+          givenByRole: 'presenting_scorer'
+        })
+      }
+
+      setScoringHand(null)
+      setSelectedScore(0)
+    } catch (err) {
+      console.error('Score error:', err)
+      alert('給分失敗：' + err.message)
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  if (!presentingScorerOwnerId) {
+    return <div style={{ color: '#999' }}>等待評分者聲稱...</div>
+  }
+
+  return (
+    <div style={{ marginTop: 16, padding: 12, backgroundColor: '#e7f3ff', borderRadius: 4, border: '1px solid #91d5ff' }}>
+      <h3 style={{ marginTop: 0, color: '#0050b3' }}>✍️ 給分介面</h3>
+
+      {hands.length === 0 ? (
+        <div style={{ color: '#999', fontStyle: 'italic' }}>目前沒有學生舉手</div>
+      ) : (
+        <div>
+          <p style={{ marginBottom: 12, fontSize: '0.9em', color: '#666' }}>
+            等待評分的舉手：{hands.length} 個
+          </p>
+
+          <div style={{ display: 'flex', flexDirection: 'column', gap: 8 }}>
+            {hands.map((hand, idx) => (
+              <div
+                key={hand.id}
+                style={{
+                  padding: 8,
+                  backgroundColor: scoringHand?.id === hand.id ? '#fff7e6' : '#f0f2f5',
+                  borderRadius: 4,
+                  border: scoringHand?.id === hand.id ? '2px solid #faad14' : '1px solid #d9d9d9',
+                  cursor: 'pointer',
+                  transition: 'all 0.2s'
+                }}
+                onClick={() => setScoringHand(hand)}
+              >
+                <div style={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center' }}>
+                  <span style={{ fontWeight: 'bold' }}>
+                    #{idx + 1} - 組別 {hand.group}
+                  </span>
+                  <span style={{ fontSize: '0.85em', color: '#999' }}>
+                    {hand.timestamp?.toLocaleTimeString?.() || '時間'}
+                  </span>
+                </div>
+
+                {scoringHand?.id === hand.id && (
+                  <div style={{ marginTop: 8, paddingTop: 8, borderTop: '1px solid #d9d9d9' }}>
+                    <div style={{ marginBottom: 8 }}>選擇分數：</div>
+                    <div style={{ display: 'flex', gap: 8, marginBottom: 8 }}>
+                      {[0, 1, 2, 3].map(score => (
+                        <button
+                          key={score}
+                          onClick={() => setSelectedScore(score)}
+                          style={{
+                            padding: '6px 12px',
+                            backgroundColor: selectedScore === score ? '#1890ff' : '#f0f0f0',
+                            color: selectedScore === score ? '#fff' : '#000',
+                            border: 'none',
+                            borderRadius: 4,
+                            cursor: 'pointer',
+                            fontWeight: 'bold',
+                            transition: 'all 0.2s'
+                          }}
+                        >
+                          {score}
+                        </button>
+                      ))}
+                    </div>
+                    <div style={{ display: 'flex', gap: 8 }}>
+                      <button
+                        onClick={() => handleScore(hand.id)}
+                        disabled={loading || selectedScore < 0 || selectedScore > 3}
+                        style={{
+                          padding: '6px 16px',
+                          backgroundColor: '#52c41a',
+                          color: '#fff',
+                          border: 'none',
+                          borderRadius: 4,
+                          cursor: 'pointer',
+                          fontWeight: 'bold'
+                        }}
+                      >
+                        {loading ? '提交中...' : '確認給分'}
+                      </button>
+                      <button
+                        onClick={() => setScoringHand(null)}
+                        style={{
+                          padding: '6px 16px',
+                          backgroundColor: '#f5f5f5',
+                          color: '#000',
+                          border: '1px solid #d9d9d9',
+                          borderRadius: 4,
+                          cursor: 'pointer'
+                        }}
+                      >
+                        取消
+                      </button>
+                    </div>
+                  </div>
+                )}
+              </div>
+            ))}
+          </div>
+        </div>
+      )}
+    </div>
+  )
+}

--- a/src/components/PresentingGroupScorer.jsx
+++ b/src/components/PresentingGroupScorer.jsx
@@ -104,7 +104,7 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
   }
 
   if (!presentingScorerOwnerId) {
-    return <div style={{ color: '#999' }}>等待評分者聲稱...</div>
+    return <div style={{ color: '#999' }}>尚未指定評分者</div>
   }
 
   return (

--- a/src/components/PresentingGroupScorer.jsx
+++ b/src/components/PresentingGroupScorer.jsx
@@ -8,22 +8,20 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
   const [loading, setLoading] = useState(false)
   const [scoringHand, setScoringHand] = useState(null) // Currently scoring hand
   const [selectedScore, setSelectedScore] = useState(0)
-  const [participantId, setParticipantId] = useState(null)
+  const [studentAccount, setStudentAccount] = useState(null)
   const [error, setError] = useState(null)
 
-  // Get current participant ID (same logic as RaiseHandButton)
+  // Get student account from localStorage
   useEffect(() => {
-    let id = null
     try {
-      const params = new URLSearchParams(window.location.search)
-      id = params.get('participantId') || null
+      const authStr = typeof window !== 'undefined' ? localStorage.getItem('studentAuth') : null
+      if (authStr) {
+        const auth = JSON.parse(authStr)
+        setStudentAccount(auth.account || null)
+      }
     } catch (e) {
-      id = null
+      console.error('Failed to get student account:', e)
     }
-    if (!id) {
-      id = `p_${Date.now()}_${Math.floor(Math.random()*10000)}`
-    }
-    setParticipantId(id)
   }, [])
 
   // Listen for raised hands in current group
@@ -66,8 +64,8 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
       return
     }
 
-    // Check authorization
-    if (participantId !== presentingScorerOwnerId) {
+    // Check authorization using student account
+    if (studentAccount !== presentingScorerOwnerId) {
       setError('非報告組組長，無法給分')
       return
     }
@@ -83,7 +81,7 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
           classId,
           handId,
           points: selectedScore,
-          givenBy: participantId
+          givenBy: studentAccount
         })
       })
 
@@ -112,7 +110,7 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
       <h3 style={{ marginTop: 0, color: '#0050b3' }}>✍️ 給分介面</h3>
 
       {/* Authorization check */}
-      {participantId && presentingScorerOwnerId && participantId !== presentingScorerOwnerId && (
+      {studentAccount && presentingScorerOwnerId && studentAccount !== presentingScorerOwnerId && (
         <div style={{ padding: 8, backgroundColor: '#fff1f0', border: '1px solid #ffa39e', borderRadius: 4, marginBottom: 12, color: '#c41d7f' }}>
           ⚠️ 你不是評分者，無法給分
         </div>
@@ -142,12 +140,12 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
                   backgroundColor: scoringHand?.id === hand.id ? '#fff7e6' : '#f0f2f5',
                   borderRadius: 4,
                   border: scoringHand?.id === hand.id ? '2px solid #faad14' : '1px solid #d9d9d9',
-                  cursor: participantId === presentingScorerOwnerId ? 'pointer' : 'not-allowed',
-                  opacity: participantId === presentingScorerOwnerId ? 1 : 0.6,
+                  cursor: studentAccount === presentingScorerOwnerId ? 'pointer' : 'not-allowed',
+                  opacity: studentAccount === presentingScorerOwnerId ? 1 : 0.6,
                   transition: 'all 0.2s'
                 }}
                 onClick={() => {
-                  if (participantId === presentingScorerOwnerId) {
+                  if (studentAccount === presentingScorerOwnerId) {
                     setScoringHand(hand)
                   }
                 }}

--- a/src/components/PresentingGroupScorer.jsx
+++ b/src/components/PresentingGroupScorer.jsx
@@ -107,7 +107,7 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
 
   return (
     <div style={{ marginTop: 16, padding: 12, backgroundColor: '#e7f3ff', borderRadius: 4, border: '1px solid #91d5ff' }}>
-      <h3 style={{ marginTop: 0, color: '#0050b3' }}>✍️ 給分介面</h3>
+      <h3 style={{ marginTop: 0, color: '#0050b3' }}>✍️ 給分介面 (評分者：{presentingScorerOwnerId})</h3>
 
       {/* Authorization check */}
       {studentAccount && presentingScorerOwnerId && studentAccount !== presentingScorerOwnerId && (

--- a/src/components/PresentingGroupScorer.jsx
+++ b/src/components/PresentingGroupScorer.jsx
@@ -24,22 +24,25 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
     }
   }, [])
 
-  // Listen for raised hands in current group
+  // Listen for raised hands in current class (all groups, not just presenting group)
   useEffect(() => {
-    if (!classId || !group) return
+    if (!classId) return
 
     try {
-      // Convert group to match Firestore format
-      const groupStr = String(group)
+      console.log('🎯 PresentingGroupScorer listening for all hands in class:', classId)
       const col = collection(db, 'hands_raised')
+      // Query ALL raised hands in this class, not filtered by group
       const q = query(
         col,
         where('classId', '==', classId),
-        where('group', '==', groupStr),
         where('active', '==', true)
       )
 
       const unsub = onSnapshot(q, (snapshot) => {
+        console.log('📝 Hands snapshot:', snapshot.docs.length, 'documents')
+        snapshot.docs.forEach(doc => {
+          console.log('  Hand:', doc.data())
+        })
         const hands = snapshot.docs.map(doc => ({
           id: doc.id,
           ...doc.data(),
@@ -56,7 +59,7 @@ export default function PresentingGroupScorer({ classId, group, presentingScorer
     } catch (e) {
       console.error('subscribe hands error:', e)
     }
-  }, [classId, group, db])
+  }, [classId, db])
 
   const handleScore = async (handId) => {
     if (!handId || selectedScore < 0 || selectedScore > 3) {

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -147,7 +147,7 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
         !presentingScorerOwnerId ? (
           isUserInPresentingGroup() ? (
             <div>
-              <div style={{ marginBottom: 8, color: '#d46b08' }}>⏳ 報告中：等待指定評分者，無法舉手</div>
+              <div style={{ marginBottom: 8, color: '#d46b08' }}>⏳ 報告組</div>
               <button onClick={claimScorer} disabled={loading}>我負責評分</button>
             </div>
           ) : (

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -178,7 +178,7 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
           // Scorer has been assigned
           isUserInPresentingGroup() ? (
             <div style={{ color: '#666', fontSize: '0.9em' }}>
-              ✓ 報告組正在評分
+              ✓ 報告組正在評分 (評分者：{presentingScorerOwnerId})
             </div>
           ) : (
             // Other groups can now raise hand

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -8,8 +8,22 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   const [raised, setRaised] = useState(false)
   const [activeDocId, setActiveDocId] = useState(null)
   const [participantId, setParticipantId] = useState(null)
+  const [studentAccount, setStudentAccount] = useState(null)
   const [presentingGroupId, setPresentingGroupId] = useState(null)
   const [presentingScorerOwnerId, setPresentingScorerOwnerId] = useState(null)
+
+  useEffect(() => {
+    // Get student account from localStorage
+    try {
+      const authStr = typeof window !== 'undefined' ? localStorage.getItem('studentAuth') : null
+      if (authStr) {
+        const auth = JSON.parse(authStr)
+        setStudentAccount(auth.account || null)
+      }
+    } catch (e) {
+      console.error('Failed to get student account:', e)
+    }
+  }, [])
 
   useEffect(() => {
     // allow overriding participant id via URL param for testing (e.g. ?participantId=p_123)
@@ -103,9 +117,12 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   }
 
   const claimScorer = async () => {
-    if (!classId || !participantId) return
+    if (!classId || !studentAccount) {
+      alert('無法取得學生資訊')
+      return
+    }
     try {
-      await updateDoc(doc(db, 'classes', classId), { presentingScorerOwnerId: participantId })
+      await updateDoc(doc(db, 'classes', classId), { presentingScorerOwnerId: studentAccount })
     } catch (err) {
       console.error('claim scorer error:', err)
       alert('設定評分者失敗')

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -28,6 +28,9 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
 
   useEffect(() => {
     if (!participantId || !classId) return
+
+    const unsubs = []
+
     // listen for presentingGroupId and presentingScorerOwnerId changes
     try {
       const classRef = doc(db, 'classes', classId)
@@ -41,25 +44,34 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
           setPresentingScorerOwnerId(null)
         }
       }, (err) => console.error('Class listen error:', err))
-
-      return () => unsubClass()
+      unsubs.push(unsubClass)
     } catch (e) {
       console.error('subscribe class doc error:', e)
     }
-    const col = collection(db, 'hands_raised')
-    const q = query(col, where('classId', '==', classId), where('ownerId', '==', participantId), where('active', '==', true))
-    const unsub = onSnapshot(q, (snapshot) => {
-      const has = snapshot.docs.length > 0
-      setRaised(has)
-      if (has) {
-        setActiveDocId(snapshot.docs[0].id)
-      } else {
-        setActiveDocId(null)
-      }
-    }, (err) => {
-      console.error('RaiseHand listen error:', err)
-    })
-    return () => unsub()
+
+    // listen for hands_raised changes
+    try {
+      const col = collection(db, 'hands_raised')
+      const q = query(col, where('classId', '==', classId), where('ownerId', '==', participantId), where('active', '==', true))
+      const unsub = onSnapshot(q, (snapshot) => {
+        const has = snapshot.docs.length > 0
+        setRaised(has)
+        if (has) {
+          setActiveDocId(snapshot.docs[0].id)
+        } else {
+          setActiveDocId(null)
+        }
+      }, (err) => {
+        console.error('RaiseHand listen error:', err)
+      })
+      unsubs.push(unsub)
+    } catch (e) {
+      console.error('hands_raised listen error:', e)
+    }
+
+    return () => {
+      unsubs.forEach(unsub => typeof unsub === 'function' && unsub())
+    }
   }, [participantId, classId])
 
   const handleClick = async () => {

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -75,10 +75,17 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   }, [participantId, classId])
 
   const handleClick = async () => {
-    // If this group is currently presenting and no scorer assigned, prevent raising
-    if (isUserInPresentingGroup() && !presentingScorerOwnerId) {
-      alert('目前尚未指定評分者，報告組無法舉手')
-      return
+    // If a group is currently presenting, only that group can raise hands
+    if (presentingGroupId) {
+      if (!isUserInPresentingGroup()) {
+        alert('目前有其他組正在報告中，無法舉手')
+        return
+      }
+      // If in presenting group but scorer not assigned
+      if (!presentingScorerOwnerId) {
+        alert('目前尚未指定評分者，報告組無法舉手')
+        return
+      }
     }
     if (raised || loading) return
     setLoading(true)
@@ -134,26 +141,39 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
 
   return (
     <div>
-      {/* If this group is currently presenting and no scorer assigned, show claim button and block raising */}
-      {isUserInPresentingGroup() && !presentingScorerOwnerId ? (
-        <div>
-          <div style={{ marginBottom: 8 }}>目前報告中：等待指定評分者，無法舉手</div>
-          <button onClick={claimScorer} disabled={loading}>我負責評分</button>
-        </div>
-      ) : isUserInPresentingGroup() && presentingScorerOwnerId ? (
-        <div style={{ color: '#666', fontSize: '0.9em' }}>
-          ✓ 報告組成員無法舉手（給分者已指定）
-        </div>
-      ) : (!raised ? (
-        <button onClick={handleClick} disabled={loading}>
-          {loading ? "提交中…" : "舉手"}
-        </button>
+      {/* If a group is currently presenting */}
+      {presentingGroupId ? (
+        isUserInPresentingGroup() ? (
+          // User is in the presenting group
+          !presentingScorerOwnerId ? (
+            <div>
+              <div style={{ marginBottom: 8, color: '#d46b08' }}>⏳ 報告中：等待指定評分者，無法舉手</div>
+              <button onClick={claimScorer} disabled={loading}>我負責評分</button>
+            </div>
+          ) : (
+            <div style={{ color: '#666', fontSize: '0.9em' }}>
+              ✓ 報告組成員無法舉手（給分者已指定）
+            </div>
+          )
+        ) : (
+          // User is NOT in the presenting group
+          <div style={{ color: '#cf1322', fontSize: '0.9em' }}>
+            ⏸ 「{presentingGroupId}組」正在報告中，其他組別無法舉手
+          </div>
+        )
       ) : (
-        <div>
-          <span style={{ marginRight: 8 }}>已舉手</span>
-          <button onClick={handleCancel} disabled={loading}>取消舉手</button>
-        </div>
-      ))}
+        // No group is presenting - normal raise hand
+        !raised ? (
+          <button onClick={handleClick} disabled={loading}>
+            {loading ? "提交中…" : "舉手"}
+          </button>
+        ) : (
+          <div>
+            <span style={{ marginRight: 8 }}>已舉手</span>
+            <button onClick={handleCancel} disabled={loading}>取消舉手</button>
+          </div>
+        )
+      )}
     </div>
   )
 }

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -41,7 +41,7 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   }, [])
 
   useEffect(() => {
-    if (!participantId || !classId) return
+    if (!participantId || !classId || !db) return
 
     const unsubs = []
 
@@ -86,7 +86,7 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
     return () => {
       unsubs.forEach(unsub => typeof unsub === 'function' && unsub())
     }
-  }, [participantId, classId])
+  }, [participantId, classId, db])
 
   const handleClick = async () => {
     // If a group is currently presenting, only that group can raise hands

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -89,17 +89,19 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   }, [participantId, classId, db])
 
   const handleClick = async () => {
-    // If a group is currently presenting, only that group can raise hands
+    // If a group is currently presenting
     if (presentingGroupId) {
-      if (!isUserInPresentingGroup()) {
-        alert('目前有其他組正在報告中，無法舉手')
+      if (isUserInPresentingGroup()) {
+        // Presenting group members cannot raise hand (they are scoring)
+        alert('報告組正在評分，無法舉手')
         return
       }
-      // If in presenting group but scorer not assigned
+      // For other groups: can only raise if scorer is assigned
       if (!presentingScorerOwnerId) {
-        alert('目前尚未指定評分者，報告組無法舉手')
+        alert('報告組尚未指定評分者，無法舉手')
         return
       }
+      // If scorer is assigned, others can raise
     }
     if (raised || loading) return
     setLoading(true)
@@ -176,12 +178,20 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
           // Scorer has been assigned
           isUserInPresentingGroup() ? (
             <div style={{ color: '#666', fontSize: '0.9em' }}>
-              ✓ 報告組成員無法舉手（給分者已指定）
+              ✓ 報告組正在評分
             </div>
           ) : (
-            <div style={{ color: '#cf1322', fontSize: '0.9em' }}>
-              ⏸ 「{presentingGroupId}組」正在報告中，其他組別無法舉手
-            </div>
+            // Other groups can now raise hand
+            !raised ? (
+              <button onClick={handleClick} disabled={loading}>
+                {loading ? "提交中…" : "舉手"}
+              </button>
+            ) : (
+              <div>
+                <span style={{ marginRight: 8 }}>已舉手</span>
+                <button onClick={handleCancel} disabled={loading}>取消舉手</button>
+              </div>
+            )
           )
         )
       ) : (

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -8,6 +8,8 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   const [raised, setRaised] = useState(false)
   const [activeDocId, setActiveDocId] = useState(null)
   const [participantId, setParticipantId] = useState(null)
+  const [presentingGroupId, setPresentingGroupId] = useState(null)
+  const [presentingScorerOwnerId, setPresentingScorerOwnerId] = useState(null)
 
   useEffect(() => {
     // allow overriding participant id via URL param for testing (e.g. ?participantId=p_123)
@@ -26,6 +28,24 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
 
   useEffect(() => {
     if (!participantId || !classId) return
+    // listen for presentingGroupId and presentingScorerOwnerId changes
+    try {
+      const classRef = doc(db, 'classes', classId)
+      const unsubClass = onSnapshot(classRef, (snap) => {
+        if (snap && typeof snap.data === 'function') {
+          const data = snap.data() || {}
+          setPresentingGroupId(data.presentingGroupId || null)
+          setPresentingScorerOwnerId(data.presentingScorerOwnerId || null)
+        } else {
+          setPresentingGroupId(null)
+          setPresentingScorerOwnerId(null)
+        }
+      }, (err) => console.error('Class listen error:', err))
+
+      return () => unsubClass()
+    } catch (e) {
+      console.error('subscribe class doc error:', e)
+    }
     const col = collection(db, 'hands_raised')
     const q = query(col, where('classId', '==', classId), where('ownerId', '==', participantId), where('active', '==', true))
     const unsub = onSnapshot(q, (snapshot) => {
@@ -43,6 +63,11 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   }, [participantId, classId])
 
   const handleClick = async () => {
+    // If this group is currently presenting and no scorer assigned, prevent raising
+    if (presentingGroupId && presentingGroupId === group && !presentingScorerOwnerId) {
+      alert('目前尚未指定評分者，報告組無法舉手')
+      return
+    }
     if (raised || loading) return
     setLoading(true)
     try {
@@ -55,6 +80,16 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
       console.error("舉手錯誤：", err)
     } finally {
       setLoading(false)
+    }
+  }
+
+  const claimScorer = async () => {
+    if (!classId || !participantId) return
+    try {
+      await updateDoc(doc(db, 'classes', classId), { presentingScorerOwnerId: participantId })
+    } catch (err) {
+      console.error('claim scorer error:', err)
+      alert('設定評分者失敗')
     }
   }
 
@@ -78,7 +113,13 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
 
   return (
     <div>
-      {!raised ? (
+      {/* If this group is currently presenting and no scorer assigned, show claim button and block raising */}
+      {presentingGroupId && presentingGroupId === group && !presentingScorerOwnerId ? (
+        <div>
+          <div style={{ marginBottom: 8 }}>目前報告中：等待指定評分者，無法舉手</div>
+          <button onClick={claimScorer} disabled={loading}>我負責評分</button>
+        </div>
+      ) : (!raised ? (
         <button onClick={handleClick} disabled={loading}>
           {loading ? "提交中…" : "舉手"}
         </button>
@@ -87,7 +128,7 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
           <span style={{ marginRight: 8 }}>已舉手</span>
           <button onClick={handleCancel} disabled={loading}>取消舉手</button>
         </div>
-      )}
+      ))}
     </div>
   )
 }

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -143,23 +143,29 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
     <div>
       {/* If a group is currently presenting */}
       {presentingGroupId ? (
-        isUserInPresentingGroup() ? (
-          // User is in the presenting group
-          !presentingScorerOwnerId ? (
+        // When presenting group is set but scorer not assigned yet
+        !presentingScorerOwnerId ? (
+          isUserInPresentingGroup() ? (
             <div>
               <div style={{ marginBottom: 8, color: '#d46b08' }}>⏳ 報告中：等待指定評分者，無法舉手</div>
               <button onClick={claimScorer} disabled={loading}>我負責評分</button>
             </div>
           ) : (
-            <div style={{ color: '#666', fontSize: '0.9em' }}>
-              ✓ 報告組成員無法舉手（給分者已指定）
+            <div style={{ color: '#cf1322', fontSize: '0.9em' }}>
+              📋 報告組尚未指定評分者，無法舉手
             </div>
           )
         ) : (
-          // User is NOT in the presenting group
-          <div style={{ color: '#cf1322', fontSize: '0.9em' }}>
-            ⏸ 「{presentingGroupId}組」正在報告中，其他組別無法舉手
-          </div>
+          // Scorer has been assigned
+          isUserInPresentingGroup() ? (
+            <div style={{ color: '#666', fontSize: '0.9em' }}>
+              ✓ 報告組成員無法舉手（給分者已指定）
+            </div>
+          ) : (
+            <div style={{ color: '#cf1322', fontSize: '0.9em' }}>
+              ⏸ 「{presentingGroupId}組」正在報告中，其他組別無法舉手
+            </div>
+          )
         )
       ) : (
         // No group is presenting - normal raise hand

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -76,7 +76,7 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
 
   const handleClick = async () => {
     // If this group is currently presenting and no scorer assigned, prevent raising
-    if (presentingGroupId && presentingGroupId === group && !presentingScorerOwnerId) {
+    if (isUserInPresentingGroup() && !presentingScorerOwnerId) {
       alert('目前尚未指定評分者，報告組無法舉手')
       return
     }
@@ -123,13 +123,26 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
     }
   }
 
+  // Normalize group values for comparison (handle "05" vs "5" mismatch)
+  const isUserInPresentingGroup = () => {
+    if (!presentingGroupId || !group) return false
+    // Convert both to numbers for comparison to handle "05" vs "5" case
+    const presentingNum = parseInt(String(presentingGroupId), 10)
+    const groupNum = parseInt(String(group), 10)
+    return presentingNum === groupNum && !isNaN(presentingNum) && !isNaN(groupNum)
+  }
+
   return (
     <div>
       {/* If this group is currently presenting and no scorer assigned, show claim button and block raising */}
-      {presentingGroupId && presentingGroupId === group && !presentingScorerOwnerId ? (
+      {isUserInPresentingGroup() && !presentingScorerOwnerId ? (
         <div>
           <div style={{ marginBottom: 8 }}>目前報告中：等待指定評分者，無法舉手</div>
           <button onClick={claimScorer} disabled={loading}>我負責評分</button>
+        </div>
+      ) : isUserInPresentingGroup() && presentingScorerOwnerId ? (
+        <div style={{ color: '#666', fontSize: '0.9em' }}>
+          ✓ 報告組成員無法舉手（給分者已指定）
         </div>
       ) : (!raised ? (
         <button onClick={handleClick} disabled={loading}>

--- a/src/components/Scoreboard.jsx
+++ b/src/components/Scoreboard.jsx
@@ -23,7 +23,7 @@ export default function Scoreboard({ classId }) {
       console.error('Scoreboard snapshot error:', err)
     })
     return () => unsub()
-  }, [classId])
+  }, [classId, db])
 
   const groups = Object.keys(scores).sort()
 

--- a/src/components/StudentClient.jsx
+++ b/src/components/StudentClient.jsx
@@ -2,6 +2,7 @@
 import React, { useState, useEffect } from "react"
 import { useRouter } from 'next/navigation'
 import RaiseHandButton from "./RaiseHandButton"
+import PresentingGroupScorer from "./PresentingGroupScorer"
 import Scoreboard from "./Scoreboard"
 import { db } from '../firebaseClient'
 import { collection, getDocs, doc, getDoc, query, where, onSnapshot } from '../lib/firestoreWrapper'
@@ -10,9 +11,19 @@ export default function StudentClient({ classId, initialGroup }) {
   const router = useRouter()
   const [group, setGroup] = useState(null)
   const [locked, setLocked] = useState(false)
+  const [presentingGroupId, setPresentingGroupId] = useState(null)
+  const [presentingScorerOwnerId, setPresentingScorerOwnerId] = useState(null)
 
   const [classes, setClasses] = useState([])
   const [selectedClass, setSelectedClass] = useState(null)
+
+  // Check if current user is in the presenting group
+  const isUserPresentingGroupMember = () => {
+    if (!presentingGroupId || !group) return false
+    const presentingNum = parseInt(String(presentingGroupId), 10)
+    const groupNum = parseInt(String(group), 10)
+    return presentingNum === groupNum && !isNaN(presentingNum) && !isNaN(groupNum)
+  }
 
   useEffect(() => {
     if (classId) {
@@ -80,9 +91,61 @@ export default function StudentClient({ classId, initialGroup }) {
     load()
   }, [classId, router])
 
+  // Listen for presenting group info from active class
+  useEffect(() => {
+    if (!classId || !db) return
+
+    try {
+      const classRef = doc(db, 'classes', classId)
+      const unsub = onSnapshot(classRef, (snap) => {
+        if (snap && typeof snap.data === 'function') {
+          const data = snap.data() || {}
+          setPresentingGroupId(data.presentingGroupId || null)
+          setPresentingScorerOwnerId(data.presentingScorerOwnerId || null)
+        } else {
+          setPresentingGroupId(null)
+          setPresentingScorerOwnerId(null)
+        }
+      }, (err) => console.error('Listen presenting group error:', err))
+
+      return () => unsub()
+    } catch (e) {
+      console.error('subscribe class doc error:', e)
+    }
+  }, [classId])
+
   // Active class UI
   if (classId) {
     if (!group) return null
+    
+    // If user is in presenting group, show presenting group UI
+    if (isUserPresentingGroupMember()) {
+      return (
+        <div>
+          <label>
+            組別：
+            <span style={{ marginLeft: 8 }}>{group} (已鎖定 - 報告組)</span>
+          </label>
+
+          <div style={{ marginTop: 16, padding: 12, backgroundColor: '#fff3cd', borderRadius: 4, border: '1px solid #ffc107' }}>
+            <h3 style={{ marginTop: 0, color: '#856404' }}>📢 報告組</h3>
+            <RaiseHandButton classId={classId} group={group} />
+          </div>
+
+          <PresentingGroupScorer classId={classId} group={group} presentingScorerOwnerId={presentingScorerOwnerId} />
+
+          <Scoreboard classId={classId} />
+
+          {locked && (
+            <button className="btn" style={{ marginTop: 12 }} onClick={() => {
+              router.push('/')
+            }}>退出並重新選擇</button>
+          )}
+        </div>
+      )
+    }
+
+    // Normal student UI
     return (
       <div>
         <label>

--- a/src/components/StudentClient.jsx
+++ b/src/components/StudentClient.jsx
@@ -112,7 +112,7 @@ export default function StudentClient({ classId, initialGroup }) {
     } catch (e) {
       console.error('subscribe class doc error:', e)
     }
-  }, [classId])
+  }, [classId, db])
 
   // Active class UI
   if (classId) {


### PR DESCRIPTION
## Summary
Complete implementation of Issue #7: Enable presenting group members to score raised hands from other groups with 0-3 points and proper authorization validation.

## Changes
1. **Auto-detection of presenting group** - Students automatically identify if they're in the presenting group without needing URL parameters
2. **Scorer role claiming** - Presenting group members can claim the scorer role by clicking "我負責評分" button
3. **Real-time hand display** - Scorer can view all raised hands in real-time via PresentingGroupScorer component
4. **Scoring interface** - Provides 0-3 point scoring with authorization validation
5. **Permissions management** - 
   - Presenting group members cannot raise hands (they're scoring)
   - Other groups can raise hands only when scorer is assigned
   - Scorer can evaluate hands from all groups
6. **UI/UX improvements** - Simplified dashboard layout, merged sections, real-time status display
7. **Build fix** - Corrected import paths from @/ aliases to relative paths in API routes

## Key Technical Fixes
- Fixed useEffect dependencies to include `db` for proper Firestore listener restoration
- Fixed type mismatch in group comparison (handle "05" vs "5" string comparison)
- Fixed scorer identity to use permanent `studentAccount` from localStorage instead of temporary `participantId`
- Fixed PresentingGroupScorer query to monitor ALL raised hands in the class
- Removed group restriction in scoring API - scorer can now evaluate any group's raised hands

## Testing
✓ E2E test passing: `e2e/11-presenting-scorer.spec.js`
- Verify scorer role can be claimed
- Verify scorer UI disappears after claiming
- Verify other students can raise hands when scorer assigned
- Verify scoring interface displays all raised hands