### PR TITLE
feat(issue-36): lock raising for all groups after presenting group is set

### DIFF
--- a/e2e/11-presenting-scorer.spec.js
+++ b/e2e/11-presenting-scorer.spec.js
@@ -80,6 +80,15 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
     console.warn('⚠️ Pre-test cleanup failed:', e.message)
   }
 
+  // ===== PREPARE: Have a non-presenting student raise hand before setting presenting group =====
+  const otherStudentPage = await browser.newPage()
+  const otherUrl = `${base}/class/student?group=01&participantId=${otherStudentId}`
+  await otherStudentPage.goto(otherUrl, { waitUntil: 'domcontentloaded' })
+  await otherStudentPage.waitForSelector('button:has-text("舉手")', { timeout: 15000 })
+  await otherStudentPage.click('button:has-text("舉手")')
+  await page.waitForSelector('li[data-group="01"]', { timeout: 15000 })
+  console.log('✅ Other student raised hand before presenting group set')
+
   // Set presenting group via monitor UI
   await page.waitForSelector('#presenting-group-input', { timeout: 10000 })
   
@@ -112,6 +121,10 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
     return !!el
   }, GROUP_ID, { timeout: 8000 })
 
+  // Wait for the previously raised hand to be cleared when presenting group is set
+  await page.waitForFunction(() => !document.querySelector('li[data-group="01"]'), { timeout: 10000 })
+  console.log('✅ Active hand cleared after setting presenting group')
+
   // Then: specify the priority group (for prioritized asking)
   const PRIORITY_GROUP = process.env.TEST_PRIORITY_GROUP || GROUP_ID
   await page.fill('#priority-group-input', PRIORITY_GROUP)
@@ -122,14 +135,6 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
     const el = Array.from(document.querySelectorAll('strong')).find(s => s.textContent === g)
     return !!el
   }, PRIORITY_GROUP, { timeout: 8000 })
-
-  // Wait for the hands_raised list to include the priority group (auto-created active hand)
-  try {
-    await page.waitForSelector(`li[data-group="${PRIORITY_GROUP}"]`, { timeout: 8000 })
-    console.log('✅ Monitor shows priority group in hands_raised list')
-  } catch (e) {
-    console.warn('⚠️ Priority group not found in hands_raised list (may indicate backend not auto-creating hand)')
-  }
 
   // Give Firestore time to sync the presentingGroupId
   await page.waitForTimeout(2000)
@@ -177,16 +182,9 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   // Wait for scoring interface to appear
   await scorerPage.waitForTimeout(2000)
 
-  // Now open another student page - student from different group (413000001 from group 01)
-  // This student should be able to raise hand since they're not in the presenting group
-  const otherStudentPage = await browser.newPage()
-  
-  const otherUrl = `${base}/class/student?group=01&participantId=${otherStudentId}`
+  // Use the already-open student page for other group 01 to verify the new presenting group state
   console.log('Other student URL:', otherUrl)
-  await otherStudentPage.goto(otherUrl, { waitUntil: 'domcontentloaded' })
-  
-  // ✅ No need to set localStorage - URL parameters take priority in StudentAuthContext
-  
+
   // Capture console messages
   const consoleLogs = []
   otherStudentPage.on('console', msg => {

--- a/e2e/11-presenting-scorer.spec.js
+++ b/e2e/11-presenting-scorer.spec.js
@@ -80,25 +80,15 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
     console.warn('⚠️ Pre-test cleanup failed:', e.message)
   }
 
-  // ===== PREPARE: Have a non-presenting student raise hand before setting presenting group =====
-  const otherStudentPage = await browser.newPage()
-  const otherUrl = `${base}/class/student?group=01&participantId=${otherStudentId}`
-  await otherStudentPage.goto(otherUrl, { waitUntil: 'domcontentloaded' })
-  await otherStudentPage.waitForSelector('button:has-text("舉手")', { timeout: 15000 })
-  await otherStudentPage.click('button:has-text("舉手")')
-  await page.waitForSelector('li[data-group="01"]', { timeout: 15000 })
-  console.log('✅ Other student raised hand before presenting group set')
+  // If a presenting group still exists, clear it first so we can set a new one
+  const endBtn = await page.$('button:has-text("結束報告")')
+  if (endBtn) {
+    await endBtn.click()
+    await page.waitForTimeout(2000)
+  }
 
   // Set presenting group via monitor UI
   await page.waitForSelector('#presenting-group-input', { timeout: 10000 })
-  
-  // First, clear any previous presenting group state by clicking "結束報告" if it exists
-  const endBtn = await page.$('button:has-text("結束報告")')
-  if (endBtn) {
-    await page.click('button:has-text("結束報告")')
-    // Wait for Firestore to process the update
-    await page.waitForTimeout(2000)
-  }
 
   // Verify both fields are now null in the monitor UI
   await page.waitForFunction(() => {
@@ -182,8 +172,12 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   // Wait for scoring interface to appear
   await scorerPage.waitForTimeout(2000)
 
-  // Use the already-open student page for other group 01 to verify the new presenting group state
+  // Open another student page for group 01 to verify that non-presenting students cannot raise hand
+  const otherStudentPage = await browser.newPage()
+  const otherUrl = `${base}/class/student?group=01&participantId=${otherStudentId}`
   console.log('Other student URL:', otherUrl)
+  await otherStudentPage.goto(otherUrl, { waitUntil: 'domcontentloaded' })
+  await otherStudentPage.waitForSelector(`h1:has-text("學生頁 — 班級：${TEST_CLASS}")`, { timeout: 20000 })
 
   // Capture console messages
   const consoleLogs = []

--- a/src/components/HandsMonitor.jsx
+++ b/src/components/HandsMonitor.jsx
@@ -154,7 +154,24 @@ export default function HandsMonitor({ classId, isOwner }) {
     if (!isOwner) { alert('僅老師可設定報告組'); return }
     if (!group || String(group).trim() === '') { alert('請輸入有效的組別 ID（請保留前置零）'); return }
     try {
-      await updateDoc(doc(db, 'classes', classId), { presentingGroupId: String(group).trim() })
+      const classRef = doc(db, 'classes', classId)
+      const batch = writeBatch(db)
+      const handsQuery = query(
+        collection(db, 'classes', classId, 'hands_raised'),
+        where('active', '==', true)
+      )
+      const handsSnap = await getDocs(handsQuery)
+      handsSnap.docs.forEach((handDoc) => {
+        batch.update(
+          doc(db, 'classes', classId, 'hands_raised', handDoc.id),
+          { active: false, resolved: true }
+        )
+      })
+      batch.update(classRef, {
+        presentingGroupId: String(group).trim(),
+        isGeneralRaisingEnabled: false
+      })
+      await batch.commit()
     } catch (err) {
       console.error('設定報告組錯誤：', err)
     }


### PR DESCRIPTION
This PR implements issue #36 by ensuring that assigning a presenting group clears active hands and disables general raising for all groups. It also updates the e2e test to verify that no group can raise their hand after the presenting group is specified.