### PR TITLE
Feat: Issue #36 implement priority-group reset and open raising flow

### DIFF
--- a/.github/SPRINT_3.md
+++ b/.github/SPRINT_3.md
@@ -105,10 +105,17 @@
 - 老師指定報告組之後，限制各組舉手，改善 #28，為了確保教學流程順暢，需加入自動化清理邏輯。
 
 接受條件
-- Given: 老師透過 #28 的功能指定了新的報告組。
-- When: 系統寫入 presentingGroupId 時。
-- Then: 必須同時執行 `hands_raised` 集合的批次更新，將該班級所有 `status: "active"` 轉為 `resolved`。
-- And: 將 `isGeneralRaisingEnabled` 狀態重置為 `false`。
+- Scenario 1: 限制各組舉手
+  - Given: 老師透過 #28 的功能指定了新的報告組。
+  - When: 系統寫入 presentingGroupId 時。
+  - Then: 必須同時執行 `hands_raised` 集合的批次更新，將該班級所有 `status: "active"` 轉為 `resolved`。
+  - And: 將 `isGeneralRaisingEnabled` 狀態重置為 `false`。
+  - And: 若先前已指定 `priorityGroupId`，需一併清除 `priorityGroupId`，確保新報告流程重新開始。
+- Scenario 2: 設定優先發問組後開放舉手
+  - Given: 已設定新的報告組，且老師指定了 `priorityGroupId`。
+  - When: 老師點擊「開放舉手」按鈕。
+  - Then: 將 `isGeneralRaisingEnabled` 狀態重置為 `true`。
+  - And: 只有在 `priorityGroupId` 已設定後，才可顯示並點選「開放舉手」按鈕。
 
 需澄清問題（已回覆）
 - 資料量小（上限約 15 組），不需要考慮原子性（決定：不需 transaction，分批或單次更新皆可）。

--- a/e2e/11-presenting-scorer.spec.js
+++ b/e2e/11-presenting-scorer.spec.js
@@ -125,6 +125,9 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   await page.fill('#presenting-group-input', GROUP_ID)
   await page.click('button:has-text("設為報告組")')
 
+  // Open raising should not be available until priority group is set
+  await expect(page.locator('button:has-text("開放舉手")')).toHaveCount(0)
+
   // Wait for the monitor UI to reflect presenting group
   await page.waitForFunction((g) => {
     const el = Array.from(document.querySelectorAll('strong')).find(s => s.textContent === g)
@@ -152,8 +155,9 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   // Give Firestore time to sync the presentingGroupId
   await page.waitForTimeout(2000)
 
-  // Open a student dashboard page in a separate browser context to verify the priority group banner
-  const priorityStudentPage = await browser.newPage()
+  // Open a student dashboard page in a dedicated browser context to verify the priority group banner
+  const priorityStudentContext = await browser.newContext()
+  const priorityStudentPage = await priorityStudentContext.newPage()
   const priorityStudentAuth = {
     account: priorityStudentId,
     name: `Test Student ${priorityStudentId}`,
@@ -171,10 +175,12 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   await expect(priorityStudentPage.locator(`text=你是優先發問組 ${PRIORITY_GROUP} 組`)).toBeVisible({ timeout: 15000 })
   console.log(`✅ Priority group banner visible for group ${PRIORITY_GROUP}`)
   await priorityStudentPage.close()
+  await priorityStudentContext.close()
 
-  // Open a student page in a separate browser context to simulate claiming scorer
+  // Open a student page in a dedicated browser context to simulate claiming scorer
   // Student 413000005 from group 04 will claim the scorer role
-  const scorerPage = await browser.newPage()
+  const scorerContext = await browser.newContext()
+  const scorerPage = await scorerContext.newPage()
   const scorerAuthData = {
     account: scorerStudentId,
     name: `Test Student ${scorerStudentId}`,
@@ -271,7 +277,8 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   expect(scoreBody.givenBy).toBe(`group-${GROUP_ID}`)
 
   // Open another student page for group 01 to verify that non-presenting students cannot raise hand
-  const otherStudentPage = await browser.newPage()
+  const otherStudentContext = await browser.newContext()
+  const otherStudentPage = await otherStudentContext.newPage()
   const otherStudentAuthData = {
     account: otherStudentId,
     name: `Test Student ${otherStudentId}`,
@@ -311,8 +318,24 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   // Expect a banner/message indicating raising is not open
   await expect(otherStudentPage.locator('text=尚未開放發問')).toHaveCount(1)
 
-  // ===== CLEANUP: Clear presenting group state for next test =====
-  console.log('🧹 Cleaning up presenting group state...')
+  // Teacher opens raising so other students can raise again
+  const openRaisingBtn = page.locator('button:has-text("開放舉手")')
+  await expect(openRaisingBtn).toHaveCount(1)
+  await openRaisingBtn.click()
+  await page.waitForTimeout(2000)
+  await otherStudentPage.waitForTimeout(5000)
+
+  // After opening raising, priority group info should be cleared
+  await expect(page.locator('text=已指定優先發問組')).toHaveCount(0)
+  await expect(page.locator('text=你是優先發問組')).toHaveCount(0)
+
+  await expect(otherStudentPage.locator('button:has-text("舉手")')).toHaveCount(1)
+  await expect(otherStudentPage.locator('text=尚未開放發問')).toHaveCount(0)
+  await otherStudentPage.click('button:has-text("舉手")')
+  await otherStudentPage.waitForTimeout(2000)
+  await expect(otherStudentPage.locator('button:has-text("取消舉手")')).toHaveCount(1)
+
+  // ===== CLEANUP: Clear presenting group state for next test =====n  console.log('🧹 Cleaning up presenting group state...')
   try {
     const endPresentingBtn = page.locator('button:has-text("結束報告")')
     if (await endPresentingBtn.count() > 0) {
@@ -325,5 +348,7 @@ test('presenting group: assign scorer and allow raising', async ({ page, browser
   }
 
   await scorerPage.close()
+  await scorerContext.close()
   await otherStudentPage.close()
+  await otherStudentContext.close()
 })

--- a/src/components/HandsMonitor.jsx
+++ b/src/components/HandsMonitor.jsx
@@ -8,6 +8,7 @@ export default function HandsMonitor({ classId, isOwner }) {
   const [presentingGroup, setPresentingGroup] = useState(null)
   const [priorityGroup, setPriorityGroup] = useState(null)
   const [presentingScorerOwnerId, setPresentingScorerOwnerId] = useState(null)
+  const [generalRaisingEnabled, setGeneralRaisingEnabled] = useState(true)
 
   useEffect(() => {
     if (!classId) return
@@ -35,10 +36,12 @@ export default function HandsMonitor({ classId, isOwner }) {
         setPresentingGroup(data.presentingGroupId || null)
         setPriorityGroup(data.priorityGroupId || null)
         setPresentingScorerOwnerId(data.presentingScorerOwnerId || null)
+        setGeneralRaisingEnabled(data.isGeneralRaisingEnabled !== false)
       } else {
         setPresentingGroup(null)
         setPriorityGroup(null)
         setPresentingScorerOwnerId(null)
+        setGeneralRaisingEnabled(true)
       }
     }, (err) => console.error('class doc snapshot error:', err))
 
@@ -169,6 +172,7 @@ export default function HandsMonitor({ classId, isOwner }) {
       })
       batch.update(classRef, {
         presentingGroupId: String(group).trim(),
+        priorityGroupId: null,
         isGeneralRaisingEnabled: false
       })
       await batch.commit()
@@ -202,9 +206,18 @@ export default function HandsMonitor({ classId, isOwner }) {
   const endPresenting = async () => {
     if (!isOwner) { alert('僅老師可結束報告'); return }
     try {
-      await updateDoc(doc(db, 'classes', classId), { presentingGroupId: null, presentingScorerOwnerId: null })
+      await updateDoc(doc(db, 'classes', classId), { presentingGroupId: null, presentingScorerOwnerId: null, isGeneralRaisingEnabled: true })
     } catch (err) {
       console.error('結束報告錯誤：', err)
+    }
+  }
+
+  const openRaising = async () => {
+    if (!isOwner) { alert('僅老師可開放舉手'); return }
+    try {
+      await updateDoc(doc(db, 'classes', classId), { isGeneralRaisingEnabled: true, priorityGroupId: null })
+    } catch (err) {
+      console.error('開放舉手錯誤：', err)
     }
   }
 
@@ -251,6 +264,21 @@ export default function HandsMonitor({ classId, isOwner }) {
                     const g = document.getElementById('priority-group-input').value
                     setPriority(g)
                   }}>指定優先發問組</button>
+                </div>
+                <div style={{ marginTop: 12, padding: 10, border: '1px solid #d9d9d9', borderRadius: 6, backgroundColor: '#fafafa' }}>
+                  <div style={{ marginBottom: 8 }}>
+                    <strong>舉手狀態：</strong> {generalRaisingEnabled ? '已開放' : '已鎖定'}
+                  </div>
+                  {!generalRaisingEnabled && priorityGroup && (
+                    <button onClick={openRaising} style={{ backgroundColor: '#1890ff', color: 'white', border: 'none', padding: '6px 12px', borderRadius: 4 }}>
+                      開放舉手
+                    </button>
+                  )}
+                  {!generalRaisingEnabled && !priorityGroup && (
+                    <div style={{ color: '#8c8c8c', fontSize: '0.9em' }}>
+                      請先指定優先發問組，之後即可開放其他組舉手。
+                    </div>
+                  )}
                 </div>
             </div>
           </div>

--- a/src/components/RaiseHandButton.jsx
+++ b/src/components/RaiseHandButton.jsx
@@ -92,8 +92,8 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
   }, [participantId, classId, group, db])
 
   const handleClick = async () => {
-    // If global raising disabled or a group is presenting, disallow raising
-    if (!generalRaisingEnabled || presentingGroupId) {
+    // If global raising disabled, disallow raising
+    if (!generalRaisingEnabled) {
       alert('目前尚未開放發問')
       return
     }
@@ -167,25 +167,24 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
 
   return (
     <div>
-      {/* If a group is currently presenting, show presenting info and keep raising locked */}
-      {presentingGroupId ? (
-        isUserInPresentingGroup() ? (
-          <div>
-            <div style={{ marginBottom: 8, color: '#d46b08' }}>⏳ 報告組</div>
-            {/* Show claim button only if not already claimed as scorer */}
-            {presentingScorerOwnerId && studentAccount === presentingScorerOwnerId ? (
-              <div style={{ color: '#52c41a' }}>✓ 你是評分者</div>
-            ) : (
-              <button onClick={claimScorer} disabled={loading}>我負責評分</button>
-            )}
-          </div>
-        ) : (
-          <div style={{ color: '#cf1322', fontSize: '0.9em' }}>📢 尚未開放發問</div>
-        )
+      {presentingGroupId && isUserInPresentingGroup() ? (
+        <div>
+          <div style={{ marginBottom: 8, color: '#d46b08' }}>⏳ 報告組</div>
+          {/* Show claim button only if not already claimed as scorer */}
+          {presentingScorerOwnerId && studentAccount === presentingScorerOwnerId ? (
+            <div style={{ color: '#52c41a' }}>✓ 你是評分者</div>
+          ) : (
+            <button onClick={claimScorer} disabled={loading}>我負責評分</button>
+          )}
+        </div>
       ) : (
-        // No presenting group; respect priority or general raising state
+        // No presenting group or this student is not the presenting group
         !raised ? (
-          priorityGroupId ? (
+          generalRaisingEnabled ? (
+            <button onClick={handleClick} disabled={loading}>
+              {loading ? "提交中…" : "舉手"}
+            </button>
+          ) : priorityGroupId ? (
             <div style={{ color: '#1890ff', fontSize: '0.95em' }}>
               {isUserInPriorityGroup() ? (
                 <span>📌 你是優先發問組 ({priorityGroupId} 組)，請等待老師進一步指示。</span>
@@ -193,10 +192,6 @@ export default function RaiseHandButton({ classId, group, onRaised }) {
                 <span>📌 已指定優先發問組：{priorityGroupId} 組，其他組暫時尚未開放發問。</span>
               )}
             </div>
-          ) : generalRaisingEnabled ? (
-            <button onClick={handleClick} disabled={loading}>
-              {loading ? "提交中…" : "舉手"}
-            </button>
           ) : (
             <div style={{ color: '#cf1322', fontSize: '0.9em' }}>📢 尚未開放發問</div>
           )


### PR DESCRIPTION
This PR implements Issue #36 behavior:
- clear `priorityGroupId` when a new presenting group is set
- require a priority group to be set before "open raising" is available
- clear `priorityGroupId` when opening raising
- update teacher monitor UI and student raise logic accordingly
- extend E2E coverage in `e2e/11-presenting-scorer.spec.js`
